### PR TITLE
Added redundancy to close keybindModal

### DIFF
--- a/src/js/front-end/actions/keybinds/keybinds.js
+++ b/src/js/front-end/actions/keybinds/keybinds.js
@@ -35,6 +35,7 @@ export const keyDown = (event) => {
     if (event.key === 'Escape'){
         hideZoneElements();
         closePopups();
+        document.getElementById('keybindModal').style.display = 'none';
     };
     if (event.key === 'Enter' && !event.altKey){
         discardBoard(systemState.initiator, systemState.initiator);


### PR DESCRIPTION
Pressing Escape will now close the list of keybinds if it's still open. On my machine, letting go of Shift did not work, but it should continue to work on other machines.