### PR TITLE
Fixed removing 'null' from basic energy name

### DIFF
--- a/src/js/front-end/setup/deck-constructor/import.js
+++ b/src/js/front-end/setup/deck-constructor/import.js
@@ -230,7 +230,7 @@ export const importDecklist = (user) => {
                 entry[5] = energyUrl;
                 entry[6] = 'Energy';
                 if (name.slice(-5) === ' null'){
-                    entry[2] = name.slice(0, -5);
+                    entry[1] = name.slice(0, -5);
                 }
             } else if (!entry[4] && (!entry[5] || !entry[6])){
                 failedText.style.display = 'block';


### PR DESCRIPTION
I had put a 2 instead of a 1, which caused the "null" at the end of SVE energies exported from cubekoga to remain in the name of the card. Not sure how I didn't catch it before, I swear I tested that before opening #12. Oh well