### PR TITLE
Fixed alt+T bug

### DIFF
--- a/client/src/actions/general/change-type.js
+++ b/client/src/actions/general/change-type.js
@@ -30,18 +30,18 @@ export const changeType = (
   const cardName = card.image.faceDown ? 'card' : card.name;
   let typeName;
   if (type === 'Trainer') {
-    typeName = 'tool';
+    typeName = 'a tool';
   } else if (type === 'Energy') {
-    typeName = 'energy';
+    typeName = 'an energy';
   } else if (type === 'Pokémon') {
-    typeName = 'Pokémon';
+    typeName = 'a Pokémon';
   }
   appendMessage(
     initiator,
     determineUsername(initiator) +
       ' changed ' +
       cardName +
-      ' into an ' +
+      ' into ' +
       typeName,
     'player',
     false

--- a/client/src/actions/keybinds/keybinds.js
+++ b/client/src/actions/keybinds/keybinds.js
@@ -425,6 +425,7 @@ export const keyDown = (event) => {
         mouseClick.cardIndex,
         'Trainer'
       );
+      return; // otherwise it will also takeTurn
     }
     if (
       (event.key === 'p' || event.code === 'KeyP') &&


### PR DESCRIPTION
This PR fixes a bug that makes you draw for turn when you attempt to change the type of a card to tool with the alt+T keybind. While I was at it I also fixed changeType so now the log says "into a tool" and not "into an tool"