### PR TITLE
Added Limitless import

### DIFF
--- a/client/index.ejs
+++ b/client/index.ejs
@@ -176,6 +176,7 @@
         <div id="importBottom">
             <button id="decklistsButton">📖</button>
             <button id="importButton">Import</button>
+            <button id="importLimitlessButton">Import (Limitless)</button>
             <button id="confirmButton">Confirm</button>
             <button id="cancelButton">Cancel</button>
             <button id="saveButton" class="neutral-color">Save</button>

--- a/client/index.ejs
+++ b/client/index.ejs
@@ -176,7 +176,7 @@
         <div id="importBottom">
             <button id="decklistsButton">📖</button>
             <button id="importButton">Import</button>
-            <button id="importLimitlessButton">Import (Limitless)</button>
+            <button id="importLimitlessButton">Limitless<br><span style="white-space:nowrap">Import <span style="font-size:0.7em">(Beta)</span></span></button>
             <button id="confirmButton">Confirm</button>
             <button id="cancelButton">Cancel</button>
             <button id="saveButton" class="neutral-color">Save</button>

--- a/client/src/css/index.css
+++ b/client/src/css/index.css
@@ -738,14 +738,14 @@ ul, li {
   align-items: center;
   gap: 0.5vw;
 }
-#importButton, #confirmButton {
+#importButton, #importLimitlessButton, #confirmButton {
   background: linear-gradient(to bottom, #95c6b4, #72ab97);
   color: white;
 }
 #confirmButton {
   margin-left: 0.3vw;
 }
-#importButton {
+#importButton, #importLimitlessButton {
   cursor: pointer;
   width: 25%;
   border-radius: .5rem;
@@ -753,7 +753,7 @@ ul, li {
   border: none;
   font-weight: bold;
 }
-#importButton:hover, #confirmButton:hover {
+#importButton:hover, #importLimitlessButton:hover, #confirmButton:hover {
   background: linear-gradient(to bottom, #7bb9a2, #5faa96);
 }
 #cancelButton, #confirmButton, #saveButton {

--- a/client/src/css/index.css
+++ b/client/src/css/index.css
@@ -738,9 +738,15 @@ ul, li {
   align-items: center;
   gap: 0.5vw;
 }
-#importButton, #importLimitlessButton, #confirmButton {
+#importButton, #confirmButton {
   background: linear-gradient(to bottom, #95c6b4, #72ab97);
   color: white;
+}
+#importLimitlessButton {
+  background: linear-gradient(to bottom, #90d4a3, #6fbf85);
+  color: white;
+  font-size: 0.75em;
+  line-height: 1;
 }
 #confirmButton {
   margin-left: 0.3vw;
@@ -748,13 +754,16 @@ ul, li {
 #importButton, #importLimitlessButton {
   cursor: pointer;
   width: 25%;
+  height: 3.5vh;
   border-radius: .5rem;
-  padding: 1vh;
   border: none;
   font-weight: bold;
 }
-#importButton:hover, #importLimitlessButton:hover, #confirmButton:hover {
+#importButton:hover, #confirmButton:hover {
   background: linear-gradient(to bottom, #7bb9a2, #5faa96);
+}
+#importLimitlessButton:hover {
+  background: linear-gradient(to bottom, #7cc492, #5faf75);
 }
 #cancelButton, #confirmButton, #saveButton {
   cursor: pointer;

--- a/client/src/initialization/document-event-listeners/sidebox/import-deck.js
+++ b/client/src/initialization/document-event-listeners/sidebox/import-deck.js
@@ -94,7 +94,22 @@ export const initializeImport = () => {
     );
     const notOpp2P = !(systemState.isTwoPlayer && user === 'opp');
     if (notSpectator && notOpp2P) {
-      importDecklist(user);
+      importDecklist(user,false);
+    } else {
+      invalidText.style.display = 'block';
+    }
+  });
+
+  const importLimitlessButton = document.getElementById('importLimitlessButton');
+  importLimitlessButton.addEventListener('click', () => {
+    const user = mainDeckImportInput.style.display !== 'none' ? 'self' : 'opp';
+    const notSpectator = !(
+      document.getElementById('spectatorModeCheckbox').checked &&
+      systemState.isTwoPlayer
+    );
+    const notOpp2P = !(systemState.isTwoPlayer && user === 'opp');
+    if (notSpectator && notOpp2P) {
+      importDecklist(user,true);
     } else {
       invalidText.style.display = 'block';
     }

--- a/client/src/setup/deck-constructor/import.js
+++ b/client/src/setup/deck-constructor/import.js
@@ -35,7 +35,7 @@ const changeLanguageButton = document.getElementById('changeLanguageButton');
 
 const cardDataToID = (card) => {
   /*
-   card is espected to be as follows (things can be undefined):
+   card is expected to be as follows (things can be undefined):
    {
     "set": "set code",
     "number": "card number",
@@ -269,7 +269,7 @@ const getEnergies = (language) => {
 
 const cardDataToImageURL = (card) => {
   /*
-  card is espected to be as follows (things can be undefined):
+  card is expected to be as follows (things can be undefined):
     {
       "set": "set code",
       "number": "card number",
@@ -279,12 +279,8 @@ const cardDataToImageURL = (card) => {
     }
   */
 
-
-  //console.log(card);
-
   let set = card["set"];
   let number = card["number"];
-  //let id = card["id"];
   let id = cardDataToID(card);
   let name = card["name"];
   let region = card["region"];
@@ -357,10 +353,7 @@ const cardDataToImageURL = (card) => {
     return `https://limitlesstcg.nyc3.cdn.digitaloceanspaces.com/tpc/${set}/${set}_${number}_R_JP_LG.png`;
   }
   if(set){
-    if(!number){
-      console.log(set);
-      console.log(card);
-    }
+    if(!number) return;
     const paddedNumber = number.replace(
       /^(\d+)([a-zA-Z])?$/,
       (_, digits, letter) => {
@@ -374,6 +367,10 @@ const cardDataToImageURL = (card) => {
   return;
 }
 
+const escapeRegExp = (string) => {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 const LimitlessDecklistArray = async (decklist) => {
   // Each card will be stored as [quantity, name, set code, number, pokemontcg.io id, image url, type]
 
@@ -383,16 +380,24 @@ const LimitlessDecklistArray = async (decklist) => {
     "energy": "Energy"
   }
 
-  let response = await (await fetch('https://limitlesstcg.com/api/dm/import', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ input: decklist })
-  })).json();
+  let response;
+  try {
+    response = await (await fetch('https://limitlesstcg.com/api/dm/import', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ input: decklist })
+    })).json();
+  } catch {
+    return [];
+  }
 
   let decklistArray = [];
-  for(let card of response["cards"]){
+  const cards = response["cards"] || [];
+  const errors = response["errors"] || [];
+
+  for (let card of cards) {
     decklistArray.push([
       card["count"],
       card["name"],
@@ -406,19 +411,18 @@ const LimitlessDecklistArray = async (decklist) => {
       card_types[card["card_type"]]
     ])
   }
-  for(let error of response["errors"]){
+  for (let error of errors) {
     let card_name = error.match(/Card \"(.+)\" was not found./);
-    if(card_name){
+    if (card_name) {
       card_name = card_name[1];
-      let qty = decklist.match(RegExp('(\\d+) '+card_name.trim()));
-      if(qty){
+      let qty = decklist.match(new RegExp('(\\d+) ' + escapeRegExp(card_name.trim())));
+      if (qty) {
         decklistArray.push([
           qty[1],
           card_name,
           null,null,null,null,null
         ])
-      }
-      else{
+      } else {
         // in theory this should never happen, but sometimes Limitless adds inexplicable spaces and it ends up happening
         decklistArray.push([
           0,
@@ -428,7 +432,6 @@ const LimitlessDecklistArray = async (decklist) => {
       }
     }
   }
-  //console.log(decklistArray);
   return decklistArray;
 }
 
@@ -533,7 +536,8 @@ const DecklistArray = async (decklist,limitless) => {
     return await LimitlessDecklistArray(decklist);
   }
   let decklistArray = ptcgsimDecklistArray(decklist);
-  for(let i in decklistArray){
+  const energies = getEnergies();
+  for (let i = 0; i < decklistArray.length; i++) {
     decklistArray[i][4] = cardDataToID({
       "set": decklistArray[i][2],
       "number": decklistArray[i][3],
@@ -555,7 +559,7 @@ const DecklistArray = async (decklist,limitless) => {
       if(decklistArray[i][4]){
         decklistArray[i][6] = getOldCardType(decklistArray[i][4]);
       }
-      if(getEnergies()[decklistArray[i][1]]){
+      if(energies[decklistArray[i][1]]){
         decklistArray[i][6] = 'Energy'
       }
     }


### PR DESCRIPTION
I added a function to import the decklist using the Limitless API. This works better with Japanese cards, but the old deck import function works better in other cases (namely it recognizes more set codes), so I kept them both. Also, the Limitless import can also accept just the card name without the set and number for Trainer and Energy cards.

To do list:
- decide on the UI. Currently I've just made an "Import (Limitless)" button that sits beside the regular "Import" button
- ~~add error handling. Limitless returns errors if it can't find a card or whatever, but my code currently ignores this, so if Limitless can't find a card then the table will simply end up with one less row~~ this has now been added. The rows for the cards it couldn't find are always at the bottom, instead of wherever they should be based on the imported decklist. Most of the time the quantity also appears in that line, but sometimes it does not.
- test more thoroughly. I have reworked the old function a bit but I've done the usual tests (importing old and new cards, importing Diamond and Pearl promos, importing Unseen Forces Unowns) and it all still works. I have not tested the Limitless import thoroughly yet