### PR TITLE
Fixed Limitless TCG Pocket Deck Import

### DIFF
--- a/client/src/setup/deck-builder/core/deck-validation.mjs
+++ b/client/src/setup/deck-builder/core/deck-validation.mjs
@@ -24,7 +24,9 @@ const RULES_BY_FORMAT = {
 
 export function isPocketCard(card = {}) {
   const image = card?.image || card?.images?.large || card?.images?.small || '';
-  return String(image).includes('/tcgp/');
+  // Cards from TCGdex contain /tcgp/
+  // Cards from Limitless contain /pocket/
+  return String(image).includes('/tcgp/') || String(image).includes('/pocket/');
 }
 
 export function detectDeckFormat(deck = {}) {

--- a/client/src/setup/deck-constructor/import.js
+++ b/client/src/setup/deck-constructor/import.js
@@ -357,13 +357,15 @@ const cardDataToImageURL = (card) => {
         return letter ? paddedDigits + letter : paddedDigits;
       }
     );
-    if (/^[A-Z]\d[a-z]?$/.test(set) || set === 'P-A') {
+    if (isPocketSet(set)) {
       return `https://limitlesstcg.nyc3.cdn.digitaloceanspaces.com/pocket/${set}/${set}_${paddedNumber}_EN_SM.webp`;
     }
     return `https://limitlesstcg.nyc3.digitaloceanspaces.com/tpci/${set.replace(/ /g, '/')}/${set.replace(/ /g, '_')}_${paddedNumber}_R_${language}.png`;
   }
   return;
 };
+
+const isPocketSet = (set) => /^[A-Z]\d[a-z]?$/.test(set) || set === 'P-A';
 
 const escapeRegExp = (string) => {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -600,7 +602,7 @@ const DecklistArray = async (decklist) => {
       // Pocket-exclusive cards (e.g. X Speed) don't exist in the TCG database so
       // Limitless returns no type for them. Default to Trainer — Pocket-exclusive
       // cards that aren't Pokémon are always Trainers.
-      if (entry[2] && (/^[A-Z]\d[a-z]?$/.test(entry[2]) || entry[2] === 'P-A') && (!entry[6] || entry[6] === 'Unknown')) {
+      if (entry[2] && isPocketSet(entry[2]) && (!entry[6] || entry[6] === 'Unknown')) {
         entry[6] = 'Trainer';
       }
     }

--- a/client/src/setup/deck-constructor/import.js
+++ b/client/src/setup/deck-constructor/import.js
@@ -434,6 +434,7 @@ const ptcgsimDecklistArray = (decklist) => {
     /(\d+) (.+?) (\w{2,5}[1-9]?[A-Z]?|WBSP|NBSP|FRLG|FUT20) (\d+[a-zA-Z]?)/;
   const regexWithPRSet =
     /(\d+) (.+?) (PR-\w{2,3}) ((?:DP|HGSS|BW|XY|SM|SWSH)?)(\d+)/;
+  const regexWithPocketPromoSet = /(\d+) (.+?) (P-[A-Z]) (\d+)/;
   const regexWithSpecialSet =
     /(\d+) (.+?) ((?:\w{2,3}[a-zA-Z]\d*|\w{2,3}(?:\s+[a-zA-Z\d]+)*)(?:\s+(\w{2,3}\s*[a-zA-Z\d]+)\s*)*)$/;
   const regexWithoutSet = /(\d+) (.+?)(?=\s\d|$|(\s\d+))/;
@@ -458,6 +459,7 @@ const ptcgsimDecklistArray = (decklist) => {
     let matchWithOldSet = line.match(regexWithOldSet);
     let matchWithSet = line.match(regexWithSet);
     let matchWithPRSet = line.match(regexWithPRSet);
+    let matchWithPocketPromoSet = line.match(regexWithPocketPromoSet);
     let matchWithSpecialSet = line.match(regexWithSpecialSet);
     let matchWithoutSet = line.match(regexWithoutSet);
 
@@ -494,6 +496,17 @@ const ptcgsimDecklistArray = (decklist) => {
         null,
         undefined,
       ]);
+    } else if (matchWithPocketPromoSet) {
+      const [, quantity, name, promoSet, setNumber] = matchWithPocketPromoSet;
+      decklistArray.push([
+        parseInt(quantity),
+        name,
+        promoSet,
+        setNumber,
+        null,
+        null,
+        undefined,
+      ]);
     } else if (matchWithSpecialSet) {
       const [, quantity, name, setAll] = matchWithSpecialSet;
       const [set, setNumber] = setAll.trim().split(/(?<=\S)\s/);
@@ -525,6 +538,9 @@ const ptcgsimDecklistArray = (decklist) => {
 
 const DecklistArray = async (decklist) => {
   // Each card will be stored as [quantity, name, set code, number, pokemontcg.io id, image url, type]
+
+  const isPocketSet = (setCode) => /^[A-Z]\d[a-z]?$/.test(setCode) || setCode === 'P-A';
+
   let decklistArray = ptcgsimDecklistArray(decklist);
   const energies = getEnergies();
   for (let i = 0; i < decklistArray.length; i++) {
@@ -534,12 +550,16 @@ const DecklistArray = async (decklist) => {
       id: decklistArray[i][4],
       name: decklistArray[i][1],
     });
-    decklistArray[i][5] = cardDataToImageURL({
-      set: decklistArray[i][2],
-      number: decklistArray[i][3],
-      id: decklistArray[i][4],
-      name: decklistArray[i][1],
-    });
+
+    if (!isPocketSet(decklistArray[i][2])) {
+      decklistArray[i][5] = cardDataToImageURL({
+        set: decklistArray[i][2],
+        number: decklistArray[i][3],
+        id: decklistArray[i][4],
+        name: decklistArray[i][1],
+      });
+    }
+
     if (!decklistArray[i][6]) {
       if (decklistArray[i][2]) {
         if (decklistArray[i][3]) {
@@ -573,13 +593,27 @@ const DecklistArray = async (decklist) => {
 
     const limitlessResults = await LimitlessDecklistArray(miniDecklist);
 
+    const normalize = (s) => s.trim().toLowerCase().replace(/-/g, ' ').replace(/\s+/g, ' ');
     for (let idx of incompleteIndices) {
       const entry = decklistArray[idx];
-      const match = limitlessResults.find((r) => r[1] === entry[1]);
+      const match = limitlessResults.find((r) => normalize(r[1]) === normalize(entry[1]));
       if (match) {
         if (!entry[5] && match[5]) entry[5] = match[5];
         if ((!entry[6] || entry[6] === 'Unknown') && match[6]) entry[6] = match[6];
       }
+    }
+  }
+
+  for (const entry of decklistArray) {
+    if (entry[2] && entry[3] && isPocketSet(entry[2]) && (!entry[6] || entry[6] === 'Unknown')) {
+      entry[6] = 'Trainer';
+    }
+  }
+
+  for (const entry of decklistArray) {
+    if (entry[2] && entry[3] && isPocketSet(entry[2])) {
+      const paddedNum = String(entry[3]).padStart(3, '0');
+      entry[5] = `https://limitlesstcg.nyc3.cdn.digitaloceanspaces.com/pocket/${entry[2]}/${entry[2]}_${paddedNum}_EN_SM.webp`;
     }
   }
 

--- a/client/src/setup/deck-constructor/import.js
+++ b/client/src/setup/deck-constructor/import.js
@@ -357,6 +357,9 @@ const cardDataToImageURL = (card) => {
         return letter ? paddedDigits + letter : paddedDigits;
       }
     );
+    if (/^[A-Z]\d[a-z]?$/.test(set) || set === 'P-A') {
+      return `https://limitlesstcg.nyc3.cdn.digitaloceanspaces.com/pocket/${set}/${set}_${paddedNumber}_EN_SM.webp`;
+    }
     return `https://limitlesstcg.nyc3.digitaloceanspaces.com/tpci/${set.replace(/ /g, '/')}/${set.replace(/ /g, '_')}_${paddedNumber}_R_${language}.png`;
   }
   return;
@@ -538,9 +541,6 @@ const ptcgsimDecklistArray = (decklist) => {
 
 const DecklistArray = async (decklist) => {
   // Each card will be stored as [quantity, name, set code, number, pokemontcg.io id, image url, type]
-
-  const isPocketSet = (setCode) => /^[A-Z]\d[a-z]?$/.test(setCode) || setCode === 'P-A';
-
   let decklistArray = ptcgsimDecklistArray(decklist);
   const energies = getEnergies();
   for (let i = 0; i < decklistArray.length; i++) {
@@ -550,16 +550,12 @@ const DecklistArray = async (decklist) => {
       id: decklistArray[i][4],
       name: decklistArray[i][1],
     });
-
-    if (!isPocketSet(decklistArray[i][2])) {
-      decklistArray[i][5] = cardDataToImageURL({
-        set: decklistArray[i][2],
-        number: decklistArray[i][3],
-        id: decklistArray[i][4],
-        name: decklistArray[i][1],
-      });
-    }
-
+    decklistArray[i][5] = cardDataToImageURL({
+      set: decklistArray[i][2],
+      number: decklistArray[i][3],
+      id: decklistArray[i][4],
+      name: decklistArray[i][1],
+    });
     if (!decklistArray[i][6]) {
       if (decklistArray[i][2]) {
         if (decklistArray[i][3]) {
@@ -601,19 +597,12 @@ const DecklistArray = async (decklist) => {
         if (!entry[5] && match[5]) entry[5] = match[5];
         if ((!entry[6] || entry[6] === 'Unknown') && match[6]) entry[6] = match[6];
       }
-    }
-  }
-
-  for (const entry of decklistArray) {
-    if (entry[2] && entry[3] && isPocketSet(entry[2]) && (!entry[6] || entry[6] === 'Unknown')) {
-      entry[6] = 'Trainer';
-    }
-  }
-
-  for (const entry of decklistArray) {
-    if (entry[2] && entry[3] && isPocketSet(entry[2])) {
-      const paddedNum = String(entry[3]).padStart(3, '0');
-      entry[5] = `https://limitlesstcg.nyc3.cdn.digitaloceanspaces.com/pocket/${entry[2]}/${entry[2]}_${paddedNum}_EN_SM.webp`;
+      // Pocket-exclusive cards (e.g. X Speed) don't exist in the TCG database so
+      // Limitless returns no type for them. Default to Trainer — Pocket-exclusive
+      // cards that aren't Pokémon are always Trainers.
+      if (entry[2] && (/^[A-Z]\d[a-z]?$/.test(entry[2]) || entry[2] === 'P-A') && (!entry[6] || entry[6] === 'Unknown')) {
+        entry[6] = 'Trainer';
+      }
     }
   }
 

--- a/client/src/setup/deck-constructor/import.js
+++ b/client/src/setup/deck-constructor/import.js
@@ -145,7 +145,7 @@ const cardDataToID = (card) => {
     FRLG: 'ex6',
     BG: 'bp',
   };
-  if (oldSetCode_to_id[set]) {
+  if (oldSetCode_to_id[set] && !isPocketSet(set)) {
     return oldSetCode_to_id[set] + '-' + number;
   }
 
@@ -454,8 +454,8 @@ const ptcgsimDecklistArray = (decklist) => {
   // Process each line
   lines.forEach((line) => {
     line = line.replace(/[[\]()]/g, '');
-    //ptcglive conversion for GG/TG cards (the alt art bs) (don't apply to promo sets)
-    line = line.replace(/(?!PR-)(\w{2,3})-(\w{2,3}) (\d+)/g, '$1 $2$3');
+    //ptcglive conversion for GG/TG cards (the alt art bs) (don't apply to promo sets or Pocket promo set P-A)
+    line = line.replace(/(?!PR-|P-A)(\w{2,3})-(\w{2,3}) (\d+)/g, '$1 $2$3');
     //special case for double crisis set
     line = line.replace(/xy5-5 /g, 'DCR ');
     //special case for DPP


### PR DESCRIPTION
From Discord:
<img width="1135" height="375" alt="image" src="https://github.com/user-attachments/assets/8dcaf853-f095-4321-a657-65d9463870cb" />
## Fix text-paste import for TCG Pocket decklists

Importing a Pocket decklist copied from Limitless TCG had three issues:

- Pocket card images were broken — the existing URL builder always used the `tpci/` CDN path, which is wrong for Pocket cards
- Promo cards with set code `P-A` (e.g. Professor's Research, Poké Ball) were not parsed by any existing regex and were silently dropped
- Some card names failed to match in the Limitless API fallback due to minor formatting differences (trailing whitespace, `ex` vs `EX`, hyphenation)

### URL format comparison

| | Format | Example |
|---|---|---|
| **TCG (before)** | `tpci/{SET}/{SET}_{NUM}_R_{LANG}.png` | `tpci/TEF/TEF_001_R_EN.png` |
| **Pocket (after)** | `pocket/{SET}/{SET}_{NUM}_EN_SM.webp` | `pocket/A2b/A2b_018_EN_SM.webp` |

_(TCG decks should still use the tcpi URL)_

### Changes

**`cardDataToImageURL`** — detect Pocket set codes (`A1`, `A1a`, `A2b`, `P-A`, etc.) and return the correct Pocket CDN URL instead of the `tpci` one

**`ptcgsimDecklistArray`** — add `regexWithPocketPromoSet` to parse lines with `P-A` set codes

**`DecklistArray`** — normalize card names before matching against Limitless API results (trim, collapse whitespace, unify hyphenation); default unresolved Pocket card types to `Trainer` since Pocket-exclusive unresolvable cards are always Trainers
