### PR TITLE
Fix crashes and desyncs in card movement

### DIFF
--- a/client/src/actions/general/close-popups.js
+++ b/client/src/actions/general/close-popups.js
@@ -93,9 +93,10 @@ export const closeFullView = (event) => {
     fullViewElement.style.zIndex = '';
     fullViewElement.style.height = '';
 
-    const allImages = fullViewElement.querySelectorAll('*');
-    const targetImage = Array.from(allImages).filter((element) => {
-      return !element.attached;
+    const targetImage = Array.from(
+      fullViewElement.querySelectorAll('img')
+    ).filter((image) => {
+      return !image.attached;
     });
 
     // Revert the position of the images
@@ -107,15 +108,19 @@ export const closeFullView = (event) => {
       }
     });
 
-    const currentWidth = parseFloat(targetImage[0].clientWidth);
-    const newWidth =
-      currentWidth +
-      (targetImage[0].clientWidth / 6) * targetImage[0].energyLayer;
-    fullViewElement.style.width = newWidth + 'px';
+    if (targetImage.length > 0) {
+      const currentWidth = parseFloat(targetImage[0].clientWidth);
+      const newWidth =
+        currentWidth +
+        (targetImage[0].clientWidth / 6) * targetImage[0].energyLayer;
+      fullViewElement.style.width = newWidth + 'px';
+    }
     fullViewElement.style.zIndex = '0';
 
     // Revert the z-indexes
-    fullViewElement.parentElement.style.zIndex = '0';
+    if (fullViewElement.parentElement) {
+      fullViewElement.parentElement.style.zIndex = '0';
+    }
     document.getElementById('stadium').style.zIndex = '0';
     refreshBoard();
   }

--- a/client/src/actions/move-card-bundle/move-card-bundle.js
+++ b/client/src/actions/move-card-bundle/move-card-bundle.js
@@ -35,9 +35,14 @@ export const moveCardBundle = (
     targetIndex,
     action
   );
-  moveCard(user, initiator, oZoneId, dZoneId, index, targetIndex);
-  refreshBoard(); //refreshing the board rearranges the array of the cards on the active/bench. to prevent desyncs, refresh the board whenever a user moves a card to ensure that the array for both users is the same
-  // the issue arised when one player would refresh their board by flipping board/resizing window, changing their arrays, but the other player would still have the original arrays.
+  try {
+    moveCard(user, initiator, oZoneId, dZoneId, index, targetIndex);
+    refreshBoard(); //refreshing the board rearranges the array of the cards on the active/bench. to prevent desyncs, refresh the board whenever a user moves a card to ensure that the array for both users is the same
+    // the issue arised when one player would refresh their board by flipping board/resizing window, changing their arrays, but the other player would still have the original arrays.
+  } catch (e) {
+    console.error('Error in moveCardBundle:', e, { user, oZoneId, dZoneId, index, targetIndex, action });
+    return;
+  }
   processAction(user, emit, 'moveCardBundle', [
     oInitiator,
     oZoneId,

--- a/client/src/actions/zones/general.js
+++ b/client/src/actions/zones/general.js
@@ -227,33 +227,38 @@ export const leaveAll = (user, initiator, oZoneId, dZoneIdParam, emit = true) =>
     appendMessage(initiator, message, 'player', false);
   }
 
-  let targetImage;
-  const oZoneCount1 = oZone.getCount() - 1;
-  for (let i = oZoneCount1; i >= 0; i--) {
-    if (oZone.array[i].type === 'Pokémon') {
-      targetImage = oZone.array[i].image;
-      moveCard(user, initiator, oZoneId, dZoneId, i);
-      break;
+  try {
+    let targetImage;
+    const oZoneCount1 = oZone.getCount() - 1;
+    for (let i = oZoneCount1; i >= 0; i--) {
+      if (oZone.array[i].type === 'Pokémon') {
+        targetImage = oZone.array[i].image;
+        moveCard(user, initiator, oZoneId, dZoneId, i);
+        break;
+      }
     }
-  }
-  const oZoneCount2 = oZone.getCount() - 1;
-  for (let i = oZoneCount2; i >= 0; i--) {
-    if (oZone.array[i].type === 'Pokémon') {
+    const oZoneCount2 = oZone.getCount() - 1;
+    for (let i = oZoneCount2; i >= 0; i--) {
+      if (oZone.array[i].type === 'Pokémon') {
+        const targetIndex = dZone.array.findIndex(
+          (card) => card.image === targetImage
+        );
+        targetImage = oZone.array[i].image;
+        moveCard(user, initiator, oZoneId, dZoneId, i, targetIndex);
+      }
+    }
+    const oZoneCount3 = oZone.getCount();
+    for (let i = 0; i < oZoneCount3; i++) {
       const targetIndex = dZone.array.findIndex(
         (card) => card.image === targetImage
       );
-      targetImage = oZone.array[i].image;
-      moveCard(user, initiator, oZoneId, dZoneId, i, targetIndex);
+      moveCard(user, initiator, oZoneId, dZoneId, 0, targetIndex);
     }
+    oZone.element.style.display = 'none';
+  } catch (e) {
+    console.error('Error in leaveAll:', e, { user, oZoneId, dZoneId });
+    return;
   }
-  const oZoneCount3 = oZone.getCount();
-  for (let i = 0; i < oZoneCount3; i++) {
-    const targetIndex = dZone.array.findIndex(
-      (card) => card.image === targetImage
-    );
-    moveCard(user, initiator, oZoneId, dZoneId, 0, targetIndex);
-  }
-  oZone.element.style.display = 'none';
 
   processAction(user, emit, 'leaveAll', [oInitiator, oZoneId, dZoneId]);
 };

--- a/client/src/setup/sizing/refresh-board.js
+++ b/client/src/setup/sizing/refresh-board.js
@@ -28,6 +28,7 @@ const refreshZone = (user, zoneId) => {
         }
         const numberRotations = currentRotation / 90;
         const index = zone.array.findIndex((card) => card.image === image);
+        if (index === -1) return; // skip stale DOM references
         moveCard(user, user, zoneId, zoneId, index);
         const newIndex = zone.array.findIndex((card) => card.image === image);
         for (let i = 0; i < numberRotations; i++) {


### PR DESCRIPTION
## Summary
- Add null/bounds guards in `closeFullView` (narrow `querySelectorAll('*')` to `img`, guard empty arrays, check `parentElement`)
- Skip stale DOM references in `refreshBoard` when `zone.array` index is `-1`
- Wrap `moveCard` calls in try-catch in `moveCardBundle` and `leaveAll`, returning early on error to prevent broadcasting failed moves

## Test plan
- [x] Open and close full view on cards with and without energy attached (click outside + Escape)
- [x] Move cards between zones in a two-player game, verify both players stay in sync
- [x] Retreat a Pokémon with attached cards, verify all cards move correctly
- [x] Resize window / flip board with cards on active/bench, verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)