### PR TITLE
Add pokemontcg.io fallback provider for deck-builder search

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ PTCG-sim is primarily built with JavaScript, using Node.js, Express, and Socket.
 
 Follow these steps to run PTCG-sim on your local machine:
 
-1. **Install Dependencies:** Run `pnpm install` to install all the required dependencies.
+1. **Install Dependencies:** Install Node.js 20 or newer and pnpm, then run `pnpm install` to install all the required dependencies.
 
 2. **Create Sqlite Database:** In the server/database directory, add a file named "db.sqlite". This is needed for storing game states, which is needed for exporting/importing game states as a URL. Note that you need to add this database even if you don't intend working with the export/imports as the server expects the file to exist.
 
@@ -19,6 +19,8 @@ Follow these steps to run PTCG-sim on your local machine:
    Ensure that the URL is consistent with the one in the server.js file.
 
 4. **Start Local Server:** Use nodemon to start running `server.js` locally. You can do this from the root directory by running `pnpm start`. This will load the repository with entry point being `front-end.js`. This file initializes various global variables, sets up the DOM, and registers socket event listeners.
+
+5. **Optional card-search fallback configuration:** Set `POKEMONTCG_API_KEY` in the server environment to use authenticated pokemontcg.io limits. The fallback proxy caches successful searches for five minutes. It defaults to 20 requests per client IP, plus 25 upstream cache misses per minute and 900 per day without a key (120 per minute and 18,000 per day with a key). Override these with `POKEMONTCG_PER_IP_RATE_LIMIT`, `POKEMONTCG_GLOBAL_RATE_LIMIT`, and `POKEMONTCG_GLOBAL_DAILY_LIMIT`. When the app runs behind a trusted reverse proxy, set `TRUST_PROXY_HOPS` to the exact number of proxy hops so per-IP limiting uses the client address.
 
 Feel free to explore the codebase and play around with the sim! I'm happy to answer any questions and I'm always open to suggestions :)
 

--- a/client/src/initialization/document-event-listeners/sidebox/native-deck-builder.js
+++ b/client/src/initialization/document-event-listeners/sidebox/native-deck-builder.js
@@ -128,6 +128,7 @@ export const initializeNativeDeckBuilder = () => {
   let currentTotalSummaries = 0;
   let currentHugeResultSet = false;
   let currentProviderNotice = '';
+  let currentSearchController = null;
   let deckDirty = false;
   let flashFrame = null;
 
@@ -443,11 +444,17 @@ export const initializeNativeDeckBuilder = () => {
   const runSearch = async (options = {}) => {
     const term = (options.term ?? searchInput.value).trim();
 
+    currentSearchController?.abort();
+    const searchController = new AbortController();
+    currentSearchController = searchController;
+
     if (!term) {
       currentResults = [];
       currentRawResults = [];
       currentTotalSummaries = 0;
+      currentHugeResultSet = false;
       currentProviderNotice = '';
+      currentSearchController = null;
       searchStatus.textContent = '';
       render();
       return;
@@ -457,7 +464,12 @@ export const initializeNativeDeckBuilder = () => {
     searchStatus.textContent = `Searching for “${term}”...`;
 
     try {
-      const searchResponse = await queryCardsByName(term);
+      const searchResponse = await queryCardsByName(term, {
+        cardType: cardTypeFilter.value,
+        signal: searchController.signal,
+      });
+      if (currentSearchController !== searchController) return;
+
       currentRawResults = searchResponse.results;
       currentTotalSummaries = searchResponse.totalSummaries;
       currentHugeResultSet = searchResponse.isHugeResultSet;
@@ -466,6 +478,7 @@ export const initializeNativeDeckBuilder = () => {
 
       searchStatus.textContent = getSearchStatusText();
     } catch (error) {
+      if (searchController.signal.aborted) return;
       currentResults = [];
       currentRawResults = [];
       currentTotalSummaries = 0;
@@ -473,8 +486,11 @@ export const initializeNativeDeckBuilder = () => {
       currentProviderNotice = '';
       searchStatus.textContent = `Search failed: ${error.message}`;
     } finally {
-      searchButton.disabled = false;
-      render();
+      if (currentSearchController === searchController) {
+        currentSearchController = null;
+        searchButton.disabled = false;
+        render();
+      }
     }
   };
 
@@ -557,7 +573,12 @@ export const initializeNativeDeckBuilder = () => {
     }
   });
 
-  document.addEventListener('deck-builder-closing', loadCurrentDeck);
+  document.addEventListener('deck-builder-closing', () => {
+    currentSearchController?.abort();
+    currentSearchController = null;
+    searchButton.disabled = false;
+    loadCurrentDeck();
+  });
 
   const deckImportButton = document.getElementById('deckImportButton');
   if (deckImportButton)

--- a/client/src/initialization/document-event-listeners/sidebox/native-deck-builder.js
+++ b/client/src/initialization/document-event-listeners/sidebox/native-deck-builder.js
@@ -53,7 +53,9 @@ export const initializeNativeDeckBuilder = () => {
 
   const playButton = document.getElementById('nativeDeckBuilderPlayButton');
   const exportCsvButton = document.getElementById('nativeDeckBuilderExportCsv');
-  const importCsvLabel = document.getElementById('nativeDeckBuilderImportCsvLabel');
+  const importCsvLabel = document.getElementById(
+    'nativeDeckBuilderImportCsvLabel'
+  );
   const importCsvInput = document.getElementById('nativeDeckBuilderCsvImport');
   const clearButton = document.getElementById('nativeDeckBuilderClear');
   const deckStatus = document.getElementById('nativeDeckBuilderDeckStatus');
@@ -125,6 +127,7 @@ export const initializeNativeDeckBuilder = () => {
   let currentLoadTarget = 'self';
   let currentTotalSummaries = 0;
   let currentHugeResultSet = false;
+  let currentProviderNotice = '';
   let deckDirty = false;
   let flashFrame = null;
 
@@ -163,12 +166,15 @@ export const initializeNativeDeckBuilder = () => {
   };
 
   const getSearchStatusText = () => {
+    const notice = currentProviderNotice ? `${currentProviderNotice} ` : '';
     if (currentHugeResultSet) {
-      return `Too many results (${currentTotalSummaries}). Please redefine your search terms.`;
+      return `${notice}Too many results (${currentTotalSummaries}). Please redefine your search terms.`;
     }
-    return currentResults.length > 0
-      ? `Showing all ${currentResults.length} result(s). Click a card to add it.`
-      : 'No matching cards found.';
+    const base =
+      currentResults.length > 0
+        ? `Showing all ${currentResults.length} result(s). Click a card to add it.`
+        : 'No matching cards found.';
+    return `${notice}${base}`;
   };
 
   const switchTarget = (target) => {
@@ -359,7 +365,9 @@ export const initializeNativeDeckBuilder = () => {
 
     clearButton.style.display = hasDeckCards ? '' : 'none';
     playButton.disabled = !hasDeckCards;
-    targetAltButton.style.cursor = systemState.isTwoPlayer ? 'default' : 'pointer';
+    targetAltButton.style.cursor = systemState.isTwoPlayer
+      ? 'default'
+      : 'pointer';
     targetAltButton.style.opacity = systemState.isTwoPlayer ? '0.5' : '';
 
     if (deckStatus) {
@@ -439,6 +447,7 @@ export const initializeNativeDeckBuilder = () => {
       currentResults = [];
       currentRawResults = [];
       currentTotalSummaries = 0;
+      currentProviderNotice = '';
       searchStatus.textContent = '';
       render();
       return;
@@ -452,6 +461,7 @@ export const initializeNativeDeckBuilder = () => {
       currentRawResults = searchResponse.results;
       currentTotalSummaries = searchResponse.totalSummaries;
       currentHugeResultSet = searchResponse.isHugeResultSet;
+      currentProviderNotice = searchResponse.notice || '';
       updateVisibleResults();
 
       searchStatus.textContent = getSearchStatusText();
@@ -460,6 +470,7 @@ export const initializeNativeDeckBuilder = () => {
       currentRawResults = [];
       currentTotalSummaries = 0;
       currentHugeResultSet = false;
+      currentProviderNotice = '';
       searchStatus.textContent = `Search failed: ${error.message}`;
     } finally {
       searchButton.disabled = false;
@@ -549,13 +560,16 @@ export const initializeNativeDeckBuilder = () => {
   document.addEventListener('deck-builder-closing', loadCurrentDeck);
 
   const deckImportButton = document.getElementById('deckImportButton');
-  if (deckImportButton) deckImportButton.addEventListener('click', () => {
-    if (systemState.isTwoPlayer && currentLoadTarget === 'opp') {
-      switchTarget('self');
-      document.dispatchEvent(new CustomEvent('deck-target-changed', { detail: { target: 'self' } }));
-    }
-    render();
-  });
+  if (deckImportButton)
+    deckImportButton.addEventListener('click', () => {
+      if (systemState.isTwoPlayer && currentLoadTarget === 'opp') {
+        switchTarget('self');
+        document.dispatchEvent(
+          new CustomEvent('deck-target-changed', { detail: { target: 'self' } })
+        );
+      }
+      render();
+    });
 
   render();
 };

--- a/client/src/setup/deck-builder/__tests__/card-fallback.test.mjs
+++ b/client/src/setup/deck-builder/__tests__/card-fallback.test.mjs
@@ -1,0 +1,185 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normalizePokemonTcgCard,
+  normalizeReleaseDate,
+  queryWithFallback,
+} from '../core/card-search.mjs';
+
+// ---------------------------------------------------------------------------
+// normalizeReleaseDate
+// ---------------------------------------------------------------------------
+
+test('normalizeReleaseDate converts slashes to dashes', () => {
+  assert.equal(normalizeReleaseDate('2016/02/03'), '2016-02-03');
+});
+
+test('normalizeReleaseDate leaves dash format unchanged', () => {
+  assert.equal(normalizeReleaseDate('2016-02-03'), '2016-02-03');
+});
+
+test('normalizeReleaseDate tolerates empty input', () => {
+  assert.equal(normalizeReleaseDate(''), '');
+  assert.equal(normalizeReleaseDate(undefined), '');
+});
+
+// ---------------------------------------------------------------------------
+// normalizePokemonTcgCard — maps pokemontcg.io shape onto the canonical shape
+// ---------------------------------------------------------------------------
+
+test('normalizePokemonTcgCard maps a pokemontcg.io card to the canonical shape', () => {
+  const raw = {
+    id: 'base1-58',
+    name: 'Pikachu',
+    supertype: 'Pokémon',
+    subtypes: ['Basic'],
+    number: '58',
+    rarity: 'Common',
+    set: {
+      id: 'base1',
+      name: 'Base',
+      series: 'Base',
+      releaseDate: '1999/01/09',
+    },
+    images: {
+      small: 'https://images.pokemontcg.io/base1/58.png',
+      large: 'https://images.pokemontcg.io/base1/58_hires.png',
+    },
+  };
+
+  const card = normalizePokemonTcgCard(raw);
+
+  assert.equal(card.id, 'base1-58');
+  assert.equal(card.name, 'Pikachu');
+  assert.equal(card.supertype, 'Pokémon');
+  assert.equal(card.stage, 'Basic');
+  assert.equal(card.number, '58');
+  assert.equal(card.set.id, 'base1');
+  assert.equal(card.set.name, 'Base');
+  assert.equal(card.set.releaseDate, '1999-01-09'); // slashes normalized
+  assert.equal(card.image, 'https://images.pokemontcg.io/base1/58_hires.png');
+  assert.equal(
+    card.images.large,
+    'https://images.pokemontcg.io/base1/58_hires.png'
+  );
+  assert.equal(card._provider, 'pokemontcg');
+});
+
+test('normalizePokemonTcgCard falls back to small image when large is missing', () => {
+  const card = normalizePokemonTcgCard({
+    id: 'x',
+    name: 'X',
+    images: { small: 'https://example.com/small.png' },
+  });
+  assert.equal(card.image, 'https://example.com/small.png');
+});
+
+test('normalizePokemonTcgCard defaults supertype to Unknown', () => {
+  const card = normalizePokemonTcgCard({
+    id: 'x',
+    name: 'X',
+    images: { large: 'u' },
+  });
+  assert.equal(card.supertype, 'Unknown');
+});
+
+// ---------------------------------------------------------------------------
+// queryWithFallback — provider failover (error + timeout)
+// ---------------------------------------------------------------------------
+
+const okResult = (results) => ({
+  results,
+  totalSummaries: results.length,
+  isHugeResultSet: false,
+});
+
+test('queryWithFallback uses the primary provider when it succeeds', async () => {
+  const primary = {
+    name: 'tcgdex',
+    search: async () => okResult([{ id: 'a' }]),
+  };
+  const fallback = {
+    name: 'pokemontcg',
+    search: async () => okResult([{ id: 'b' }]),
+    fallbackNotice: 'fell back',
+  };
+
+  const res = await queryWithFallback('pikachu', {
+    providers: [primary, fallback],
+  });
+
+  assert.equal(res.provider, 'tcgdex');
+  assert.equal(res.usedFallback, false);
+  assert.equal(res.notice, '');
+  assert.deepEqual(res.results, [{ id: 'a' }]);
+});
+
+test('queryWithFallback fails over to the backup provider on error', async () => {
+  const primary = {
+    name: 'tcgdex',
+    search: async () => {
+      throw new Error('502 Bad Gateway');
+    },
+  };
+  const fallback = {
+    name: 'pokemontcg',
+    search: async () => okResult([{ id: 'b' }]),
+    fallbackNotice: 'tcgdex is unavailable',
+  };
+
+  const res = await queryWithFallback('pikachu', {
+    providers: [primary, fallback],
+  });
+
+  assert.equal(res.provider, 'pokemontcg');
+  assert.equal(res.usedFallback, true);
+  assert.equal(res.notice, 'tcgdex is unavailable');
+  assert.deepEqual(res.results, [{ id: 'b' }]);
+});
+
+test('queryWithFallback fails over when the primary is too slow', async () => {
+  const primary = {
+    name: 'tcgdex',
+    // Never resolves within the timeout window.
+    search: (_term, { signal } = {}) =>
+      new Promise((resolve) => {
+        const t = setTimeout(() => resolve(okResult([{ id: 'slow' }])), 1000);
+        if (signal) signal.addEventListener('abort', () => clearTimeout(t));
+      }),
+  };
+  const fallback = {
+    name: 'pokemontcg',
+    search: async () => okResult([{ id: 'fast' }]),
+    fallbackNotice: 'slow',
+  };
+
+  const res = await queryWithFallback('pikachu', {
+    providers: [primary, fallback],
+    timeoutMs: 20,
+  });
+
+  assert.equal(res.provider, 'pokemontcg');
+  assert.equal(res.usedFallback, true);
+  assert.deepEqual(res.results, [{ id: 'fast' }]);
+});
+
+test('queryWithFallback throws when every provider fails', async () => {
+  const boom = {
+    name: 'a',
+    search: async () => {
+      throw new Error('down');
+    },
+  };
+  const boom2 = {
+    name: 'b',
+    search: async () => {
+      throw new Error('also down');
+    },
+  };
+
+  await assert.rejects(
+    queryWithFallback('pikachu', { providers: [boom, boom2] }),
+    /also down/
+  );
+});

--- a/client/src/setup/deck-builder/__tests__/card-fallback.test.mjs
+++ b/client/src/setup/deck-builder/__tests__/card-fallback.test.mjs
@@ -2,7 +2,10 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  buildPokemonTcgQuery,
+  CARD_PROVIDERS,
   normalizePokemonTcgCard,
+  normalizePokemonTcgSearchQuery,
   normalizeReleaseDate,
   queryWithFallback,
 } from '../core/card-search.mjs';
@@ -22,6 +25,31 @@ test('normalizeReleaseDate leaves dash format unchanged', () => {
 test('normalizeReleaseDate tolerates empty input', () => {
   assert.equal(normalizeReleaseDate(''), '');
   assert.equal(normalizeReleaseDate(undefined), '');
+  assert.equal(normalizeReleaseDate(null), '');
+});
+
+test('normalizePokemonTcgSearchQuery preserves aliases for the fallback provider', () => {
+  assert.equal(
+    normalizePokemonTcgSearchQuery('Charizard delta'),
+    'Charizard δ'
+  );
+  assert.equal(normalizePokemonTcgSearchQuery('Mewtwo prism star'), 'Mewtwo ◇');
+  assert.equal(normalizePokemonTcgSearchQuery('Pikachu *'), 'Pikachu Star');
+  assert.equal(normalizePokemonTcgSearchQuery('Infernape E4'), 'Infernape 4');
+  assert.equal(
+    normalizePokemonTcgSearchQuery('Torterra LV.X'),
+    'Torterra LV.X'
+  );
+});
+
+test('buildPokemonTcgQuery uses wildcards only for safe single-word terms', () => {
+  assert.equal(buildPokemonTcgQuery('Pikachu'), 'name:Pikachu*');
+  assert.equal(buildPokemonTcgQuery('Mewtwo-EX'), 'name:"Mewtwo-EX"');
+  assert.equal(buildPokemonTcgQuery('Porygon?'), 'name:"Porygon?"');
+});
+
+test('buildPokemonTcgQuery quotes and escapes multi-word phrases', () => {
+  assert.equal(buildPokemonTcgQuery('Lt. "Surge"'), 'name:"Lt. \\"Surge\\""');
 });
 
 // ---------------------------------------------------------------------------
@@ -180,6 +208,204 @@ test('queryWithFallback throws when every provider fails', async () => {
 
   await assert.rejects(
     queryWithFallback('pikachu', { providers: [boom, boom2] }),
-    /also down/
+    (error) => {
+      assert.ok(error instanceof AggregateError);
+      assert.match(error.message, /All card providers failed/);
+      assert.equal(error.errors.length, 2);
+      assert.match(error.errors[1].message, /also down/);
+      return true;
+    }
   );
+});
+
+test('queryWithFallback skips providers that cannot serve Pocket cards', async () => {
+  let fallbackCalled = false;
+  const primary = {
+    name: 'tcgdex',
+    cardTypes: ['tcg', 'pocket'],
+    search: async () => {
+      throw new Error('down');
+    },
+  };
+  const fallback = {
+    name: 'pokemontcg',
+    cardTypes: ['tcg'],
+    search: async () => {
+      fallbackCalled = true;
+      return okResult([]);
+    },
+  };
+
+  await assert.rejects(
+    queryWithFallback('pikachu', {
+      providers: [primary, fallback],
+      cardType: 'pocket',
+    }),
+    /no fallback provider supports TCG Pocket/
+  );
+  assert.equal(fallbackCalled, false);
+});
+
+test('queryWithFallback stops immediately when its parent signal aborts', async () => {
+  const controller = new AbortController();
+  let fallbackCalled = false;
+  const primary = {
+    name: 'tcgdex',
+    search: (_term, { signal }) =>
+      new Promise((_, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => reject(new DOMException('aborted', 'AbortError')),
+          { once: true }
+        );
+      }),
+  };
+  const fallback = {
+    name: 'pokemontcg',
+    search: async () => {
+      fallbackCalled = true;
+      return okResult([]);
+    },
+  };
+
+  setTimeout(() => controller.abort(), 5);
+  await assert.rejects(
+    queryWithFallback('pikachu', {
+      providers: [primary, fallback],
+      signal: controller.signal,
+      timeoutMs: 100,
+    }),
+    (error) => error.name === 'AbortError'
+  );
+  assert.equal(fallbackCalled, false);
+});
+
+test('the real TCGdex provider fails over when every detail request fails', async (t) => {
+  t.mock.method(globalThis, 'fetch', async (url) => {
+    const value = String(url);
+    if (value.includes('/v2/en/cards?')) {
+      return new Response(JSON.stringify([{ id: 'failed-detail' }]), {
+        status: 200,
+      });
+    }
+    if (value.endsWith('/cards/failed-detail')) {
+      return new Response('down', { status: 503 });
+    }
+    throw new Error(`Unexpected URL: ${value}`);
+  });
+
+  const fallback = {
+    name: 'fallback',
+    cardTypes: ['tcg'],
+    search: async () => okResult([{ id: 'fallback-card' }]),
+    fallbackNotice: 'fell back',
+  };
+  const result = await queryWithFallback('Pikachu', {
+    providers: [CARD_PROVIDERS[0], fallback],
+    timeoutMs: 100,
+  });
+
+  assert.equal(result.provider, 'fallback');
+  assert.deepEqual(result.results, [{ id: 'fallback-card' }]);
+});
+
+test('the real TCGdex provider reports partial detail failures', async (t) => {
+  t.mock.method(globalThis, 'fetch', async (url) => {
+    const value = String(url);
+    if (value.includes('/v2/en/cards?')) {
+      return new Response(
+        JSON.stringify([{ id: 'good-detail' }, { id: 'bad-detail' }]),
+        { status: 200 }
+      );
+    }
+    if (value.endsWith('/cards/good-detail')) {
+      return new Response(
+        JSON.stringify({
+          id: 'good-detail',
+          name: 'Pikachu',
+          category: 'Pokemon',
+          image: 'https://example.test/card',
+        }),
+        { status: 200 }
+      );
+    }
+    if (value.endsWith('/cards/bad-detail')) {
+      return new Response('down', { status: 503 });
+    }
+    throw new Error(`Unexpected URL: ${value}`);
+  });
+
+  const result = await CARD_PROVIDERS[0].search('Pikachu');
+  assert.equal(result.results.length, 1);
+  assert.match(result.notice, /partial results/);
+});
+
+test('aborted set hydration is not cached as a missing date', async (t) => {
+  let setCalls = 0;
+  t.mock.method(globalThis, 'fetch', async (url, { signal } = {}) => {
+    const value = String(url);
+    if (value.includes('/v2/en/cards?')) {
+      return new Response(JSON.stringify([{ id: 'cache-test-card' }]), {
+        status: 200,
+      });
+    }
+    if (value.endsWith('/cards/cache-test-card')) {
+      return new Response(
+        JSON.stringify({
+          id: 'cache-test-card',
+          name: 'Cache Test',
+          category: 'Pokemon',
+          localId: '1',
+          image: 'https://example.test/card',
+          set: { id: 'cache-test-set', name: 'Cache Set' },
+        }),
+        { status: 200 }
+      );
+    }
+    if (value.endsWith('/sets/cache-test-set')) {
+      setCalls += 1;
+      if (setCalls === 1) {
+        return new Promise((_, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => reject(new DOMException('aborted', 'AbortError')),
+            { once: true }
+          );
+        });
+      }
+      return new Response(JSON.stringify({ releaseDate: '2025-01-02' }), {
+        status: 200,
+      });
+    }
+    throw new Error(`Unexpected URL: ${value}`);
+  });
+
+  await queryWithFallback('Cache Test', {
+    providers: [
+      CARD_PROVIDERS[0],
+      { name: 'fallback', search: async () => okResult([]) },
+    ],
+    timeoutMs: 10,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const second = await CARD_PROVIDERS[0].search('Cache Test');
+  assert.equal(setCalls, 2);
+  assert.equal(second.results[0].set.releaseDate, '2025-01-02');
+});
+
+test('the real fallback provider sends only a normalized term to the proxy', async (t) => {
+  let requestedUrl = '';
+  t.mock.method(globalThis, 'fetch', async (url) => {
+    requestedUrl = String(url);
+    return new Response(JSON.stringify({ data: [], totalCount: 0 }), {
+      status: 200,
+    });
+  });
+
+  await CARD_PROVIDERS[1].search('Charizard delta');
+  const url = new URL(requestedUrl, 'https://example.test');
+  assert.equal(url.pathname, '/api/card-fallback');
+  assert.equal(url.searchParams.get('term'), 'Charizard δ');
+  assert.deepEqual([...url.searchParams.keys()], ['term']);
 });

--- a/client/src/setup/deck-builder/core/card-search.mjs
+++ b/client/src/setup/deck-builder/core/card-search.mjs
@@ -1,9 +1,12 @@
+import { buildPokemonTcgQuery } from './pokemon-tcg-query.mjs';
+
 const HUGE_RESULT_THRESHOLD = 2000;
 const DETAIL_FETCH_LIMIT = 150;
 
-// How long a provider gets before we treat it as "slow" and fail over.
+// How long the primary provider gets before we treat it as "slow" and fail over.
 // Covers tcgdex's multi-request search (summaries + per-card details + set hydration).
 export const SEARCH_TIMEOUT_MS = 4000;
+export const FALLBACK_SEARCH_TIMEOUT_MS = 7000;
 
 const tcgdexSetReleaseDateCache = new Map();
 
@@ -150,7 +153,7 @@ export function resolveSearchPlan(term) {
 // string-based release-date sort in applyLocalControls stays consistent across
 // providers and across a mixed result set.
 export function normalizeReleaseDate(value = '') {
-  return String(value).replace(/\//g, '-');
+  return String(value || '').replace(/\//g, '-');
 }
 
 async function fetchJson(url, { signal, ...options } = {}) {
@@ -164,19 +167,66 @@ async function fetchJson(url, { signal, ...options } = {}) {
 // Races a provider search against a timeout so a slow (not just failed) provider
 // still triggers failover. `factory` receives an AbortSignal so the underlying
 // fetches can be cancelled when the timeout fires.
-export function withTimeout(factory, timeoutMs = SEARCH_TIMEOUT_MS) {
+function toAbortError(reason) {
+  if (reason instanceof Error) return reason;
+  return new DOMException('The operation was aborted', 'AbortError');
+}
+
+function isAbortError(error) {
+  return error?.name === 'AbortError';
+}
+
+export async function withTimeout(
+  factory,
+  timeoutMs = SEARCH_TIMEOUT_MS,
+  { signal: parentSignal } = {}
+) {
+  if (parentSignal?.aborted) {
+    throw toAbortError(parentSignal.reason);
+  }
+
   const controller = new AbortController();
   let timer;
+  let removeParentAbortListener = () => {};
+
   const timeout = new Promise((_, reject) => {
     timer = setTimeout(() => {
-      controller.abort();
-      reject(new Error(`Provider timed out after ${timeoutMs}ms`));
+      const error = new Error(`Provider timed out after ${timeoutMs}ms`);
+      reject(error);
+      controller.abort(error);
     }, timeoutMs);
   });
-  return Promise.race([
-    Promise.resolve(factory(controller.signal)),
-    timeout,
-  ]).finally(() => clearTimeout(timer));
+
+  const parentAbort = parentSignal
+    ? new Promise((_, reject) => {
+        let handled = false;
+        const onAbort = () => {
+          if (handled) return;
+          handled = true;
+          const error = toAbortError(parentSignal.reason);
+          reject(error);
+          controller.abort(error);
+        };
+        parentSignal.addEventListener('abort', onAbort, { once: true });
+        if (parentSignal.aborted) onAbort();
+        removeParentAbortListener = () =>
+          parentSignal.removeEventListener('abort', onAbort);
+      })
+    : null;
+
+  try {
+    const providerPromise = Promise.resolve().then(() =>
+      factory(controller.signal)
+    );
+    return await Promise.race(
+      parentAbort
+        ? [providerPromise, timeout, parentAbort]
+        : [providerPromise, timeout]
+    );
+  } finally {
+    clearTimeout(timer);
+    removeParentAbortListener();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -242,8 +292,9 @@ async function hydrateTcgdexSetReleaseDates(cards = [], signal) {
           setId,
           normalizeReleaseDate(setData?.releaseDate || '')
         );
-      } catch {
-        tcgdexSetReleaseDateCache.set(setId, '');
+      } catch (error) {
+        if (signal?.aborted || isAbortError(error)) throw error;
+        // A transient set lookup failure should be retried by a later search.
       }
     })
   );
@@ -298,19 +349,34 @@ async function searchTcgdex(term = '', { signal } = {}) {
 
   const summariesToFetch = allSummaries.slice(0, DETAIL_FETCH_LIMIT);
 
-  const detailedCards = await Promise.all(
+  const detailResults = await Promise.allSettled(
     summariesToFetch.map(async (summary) => {
-      try {
-        const detail = await fetchJson(
-          `https://api.tcgdex.net/v2/en/cards/${summary.id}`,
-          { signal }
-        );
-        return normalizeTcgdexCard(detail);
-      } catch {
-        return null;
-      }
+      const detail = await fetchJson(
+        `https://api.tcgdex.net/v2/en/cards/${summary.id}`,
+        { signal }
+      );
+      return normalizeTcgdexCard(detail);
     })
   );
+
+  if (signal?.aborted) throw toAbortError(signal.reason);
+
+  const failedDetails = detailResults.filter(
+    (result) => result.status === 'rejected'
+  );
+  const detailedCards = detailResults
+    .filter((result) => result.status === 'fulfilled')
+    .map((result) => result.value);
+
+  if (
+    detailResults.length > 0 &&
+    failedDetails.length === detailResults.length
+  ) {
+    throw new AggregateError(
+      failedDetails.map((result) => result.reason),
+      'TCGdex card details were unavailable'
+    );
+  }
 
   const validCards = detailedCards.filter((card) => card && card.image);
   const hydratedCards = await hydrateTcgdexSetReleaseDates(validCards, signal);
@@ -319,6 +385,10 @@ async function searchTcgdex(term = '', { signal } = {}) {
     results: hydratedCards,
     totalSummaries: allSummaries.length,
     isHugeResultSet: allSummaries.length > HUGE_RESULT_THRESHOLD,
+    notice:
+      failedDetails.length > 0
+        ? `TCGdex returned partial results (${failedDetails.length} card detail request(s) failed).`
+        : '',
   };
 }
 
@@ -360,16 +430,16 @@ export function normalizePokemonTcgCard(card = {}) {
 // fetch" rather than a clean status. The proxy also attaches the API key server-side.
 export const POKEMONTCG_FALLBACK_PATH = '/api/card-fallback';
 
-// Builds the Lucene-style `q` value pokemontcg.io expects. Wildcards only work
-// unquoted, so a single-word term gets a prefix wildcard while a multi-word term
-// falls back to a quoted phrase match.
-export function buildPokemonTcgQuery(cleanName) {
-  const escaped = cleanName.replace(/"/g, '\\"');
-  return cleanName.includes(' ') ? `name:"${escaped}"` : `name:${escaped}*`;
+export { buildPokemonTcgQuery };
+
+export function normalizePokemonTcgSearchQuery(term = '') {
+  const canonicalName = stripWildcards(normalizeSearchQuery(String(term)));
+  // TCGdex models LV.X through a stage filter; pokemontcg.io stores it in the name.
+  return canonicalName.replace(/\bLV\. X$/i, 'LV.X');
 }
 
 async function searchPokemonTcg(term = '', { signal } = {}) {
-  const cleanName = stripWildcards(String(term).trim());
+  const cleanName = normalizePokemonTcgSearchQuery(term);
   if (!cleanName) {
     return { results: [], totalSummaries: 0, isHugeResultSet: false };
   }
@@ -377,9 +447,7 @@ async function searchPokemonTcg(term = '', { signal } = {}) {
   // URLSearchParams (not `new URL`) so the request stays a same-origin relative
   // path in the browser and needs no base URL under Node during tests.
   const params = new URLSearchParams({
-    q: buildPokemonTcgQuery(cleanName),
-    pageSize: String(DETAIL_FETCH_LIMIT),
-    orderBy: '-set.releaseDate',
+    term: cleanName,
   });
 
   const payload = await fetchJson(`${POKEMONTCG_FALLBACK_PATH}?${params}`, {
@@ -404,10 +472,17 @@ async function searchPokemonTcg(term = '', { signal } = {}) {
 // ---------------------------------------------------------------------------
 
 export const CARD_PROVIDERS = [
-  { name: 'tcgdex', search: searchTcgdex },
+  {
+    name: 'tcgdex',
+    search: searchTcgdex,
+    cardTypes: ['tcg', 'pocket'],
+    timeoutMs: SEARCH_TIMEOUT_MS,
+  },
   {
     name: 'pokemontcg',
     search: searchPokemonTcg,
+    cardTypes: ['tcg'],
+    timeoutMs: FALLBACK_SEARCH_TIMEOUT_MS,
     fallbackNotice:
       'tcgdex is unavailable — showing results from pokemontcg.io. TCG Pocket cards are not available from this source.',
   },
@@ -415,35 +490,58 @@ export const CARD_PROVIDERS = [
 
 // Tries providers in order; each is raced against a timeout. Returns the first
 // success (annotated with which provider served it and any fallback notice), or
-// throws the last error if every provider fails.
+// throws an AggregateError if every compatible provider fails.
 export async function queryWithFallback(term = '', options = {}) {
-  const { providers = CARD_PROVIDERS, timeoutMs = SEARCH_TIMEOUT_MS } = options;
-  let lastError;
+  const {
+    providers = CARD_PROVIDERS,
+    timeoutMs,
+    cardType = 'all',
+    signal,
+  } = options;
+  const errors = [];
+  let skippedForCardType = false;
 
   for (let i = 0; i < providers.length; i += 1) {
     const provider = providers[i];
+    if (
+      cardType !== 'all' &&
+      Array.isArray(provider.cardTypes) &&
+      !provider.cardTypes.includes(cardType)
+    ) {
+      skippedForCardType = true;
+      continue;
+    }
+
     try {
       const result = await withTimeout(
         (signal) => provider.search(term, { signal }),
-        timeoutMs
+        timeoutMs ?? provider.timeoutMs ?? SEARCH_TIMEOUT_MS,
+        { signal }
       );
       return {
         ...result,
         term,
         provider: provider.name,
         usedFallback: i > 0,
-        notice: i > 0 ? provider.fallbackNotice || '' : '',
+        notice: result.notice || (i > 0 ? provider.fallbackNotice || '' : ''),
       };
     } catch (error) {
-      lastError = error;
+      if (signal?.aborted) throw error;
+      errors.push(
+        new Error(`${provider.name} failed: ${error.message}`, { cause: error })
+      );
       // Fall through to the next provider.
     }
   }
 
-  throw lastError || new Error('All card providers failed');
+  const message =
+    cardType === 'pocket' && skippedForCardType
+      ? 'TCGdex is unavailable and no fallback provider supports TCG Pocket.'
+      : 'All card providers failed.';
+  throw new AggregateError(errors, message);
 }
 
-export async function queryCardsByName(term = '') {
+export async function queryCardsByName(term = '', options = {}) {
   const raw = String(term);
 
   // Empty/whitespace-only terms short-circuit without hitting the network.
@@ -459,5 +557,5 @@ export async function queryCardsByName(term = '') {
     };
   }
 
-  return queryWithFallback(raw);
+  return queryWithFallback(raw, options);
 }

--- a/client/src/setup/deck-builder/core/card-search.mjs
+++ b/client/src/setup/deck-builder/core/card-search.mjs
@@ -1,5 +1,10 @@
 const HUGE_RESULT_THRESHOLD = 2000;
 const DETAIL_FETCH_LIMIT = 150;
+
+// How long a provider gets before we treat it as "slow" and fail over.
+// Covers tcgdex's multi-request search (summaries + per-card details + set hydration).
+export const SEARCH_TIMEOUT_MS = 4000;
+
 const tcgdexSetReleaseDateCache = new Map();
 
 function compareReleaseDate(a, b, direction = 'desc') {
@@ -7,7 +12,9 @@ function compareReleaseDate(a, b, direction = 'desc') {
   const dateB = String(b.set?.releaseDate || '');
 
   if (dateA && dateB && dateA !== dateB) {
-    return direction === 'asc' ? dateA.localeCompare(dateB) : dateB.localeCompare(dateA);
+    return direction === 'asc'
+      ? dateA.localeCompare(dateB)
+      : dateB.localeCompare(dateA);
   }
 
   if (dateA && !dateB) return direction === 'asc' ? 1 : -1;
@@ -36,14 +43,22 @@ function compareName(a, b, direction = 'asc') {
 }
 
 export function applyLocalControls(cards = [], options = {}) {
-  const { cardType = 'all', sortBy = 'releaseDate', sortDirection = 'desc' } = options;
+  const {
+    cardType = 'all',
+    sortBy = 'releaseDate',
+    sortDirection = 'desc',
+  } = options;
 
   let filtered = [...cards];
 
   if (cardType === 'pocket') {
-    filtered = filtered.filter((card) => String(card.image || '').includes('/tcgp/'));
+    filtered = filtered.filter((card) =>
+      String(card.image || '').includes('/tcgp/')
+    );
   } else if (cardType === 'tcg') {
-    filtered = filtered.filter((card) => !String(card.image || '').includes('/tcgp/'));
+    filtered = filtered.filter(
+      (card) => !String(card.image || '').includes('/tcgp/')
+    );
   }
 
   if (sortBy === 'name') {
@@ -56,7 +71,9 @@ export function applyLocalControls(cards = [], options = {}) {
 }
 
 function stripWildcards(value = '') {
-  return String(value).replace(/^\*+|\*+$/g, '').trim();
+  return String(value)
+    .replace(/^\*+|\*+$/g, '')
+    .trim();
 }
 
 // Transforms well-known user-facing suffixes into the form stored in the database.
@@ -107,24 +124,71 @@ export function resolveSearchPlan(term) {
   // LV.X: API supports ?stage=LEVEL-UP, optionally combined with ?name for the base Pokémon.
   // \b matches a word boundary so both "Torterra LV. X" and standalone "LV. X" are caught.
   if (/\bLV\. X$/i.test(term)) {
-    return { type: 'stage', stage: 'LEVEL-UP', baseName: term.replace(/\s*\bLV\. X$/i, '').trim() };
+    return {
+      type: 'stage',
+      stage: 'LEVEL-UP',
+      baseName: term.replace(/\s*\bLV\. X$/i, '').trim(),
+    };
   }
 
   // EX / GX: the database uses both "-EX"/"-GX" and " EX"/" GX" inconsistently.
   // Search both forms and merge the results.
-  if (/-EX$/i.test(term)) return { type: 'name', queries: [term, term.replace(/-EX$/i, ' EX')] };
-  if (/ EX$/i.test(term)) return { type: 'name', queries: [term, term.replace(/ EX$/i, '-EX')] };
-  if (/-GX$/i.test(term)) return { type: 'name', queries: [term, term.replace(/-GX$/i, ' GX')] };
-  if (/ GX$/i.test(term)) return { type: 'name', queries: [term, term.replace(/ GX$/i, '-GX')] };
+  if (/-EX$/i.test(term))
+    return { type: 'name', queries: [term, term.replace(/-EX$/i, ' EX')] };
+  if (/ EX$/i.test(term))
+    return { type: 'name', queries: [term, term.replace(/ EX$/i, '-EX')] };
+  if (/-GX$/i.test(term))
+    return { type: 'name', queries: [term, term.replace(/-GX$/i, ' GX')] };
+  if (/ GX$/i.test(term))
+    return { type: 'name', queries: [term, term.replace(/ GX$/i, '-GX')] };
 
   return { type: 'name', queries: [term] };
 }
 
-async function fetchCardSummaries({ cardName, cardStage } = {}) {
+// Different providers report set release dates with different separators
+// (tcgdex: YYYY-MM-DD, pokemontcg.io: YYYY/MM/DD). Normalise to dashes so the
+// string-based release-date sort in applyLocalControls stays consistent across
+// providers and across a mixed result set.
+export function normalizeReleaseDate(value = '') {
+  return String(value).replace(/\//g, '-');
+}
+
+async function fetchJson(url, { signal, ...options } = {}) {
+  const response = await fetch(url, { signal, ...options });
+  if (!response.ok) {
+    throw new Error(`Request failed (${response.status}) for ${url}`);
+  }
+  return response.json();
+}
+
+// Races a provider search against a timeout so a slow (not just failed) provider
+// still triggers failover. `factory` receives an AbortSignal so the underlying
+// fetches can be cancelled when the timeout fires.
+export function withTimeout(factory, timeoutMs = SEARCH_TIMEOUT_MS) {
+  const controller = new AbortController();
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`Provider timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  return Promise.race([
+    Promise.resolve(factory(controller.signal)),
+    timeout,
+  ]).finally(() => clearTimeout(timer));
+}
+
+// ---------------------------------------------------------------------------
+// Provider: tcgdex (primary) — covers both TCG and TCG Pocket cards.
+// Two-step: search for summaries, then fetch full detail per card.
+// ---------------------------------------------------------------------------
+
+async function fetchCardSummaries({ cardName, cardStage, signal } = {}) {
   const url = new URL('https://api.tcgdex.net/v2/en/cards');
   if (cardName) url.searchParams.set('name', cardName);
   if (cardStage) url.searchParams.set('stage', cardStage);
-  const summaries = await fetchJson(url.toString());
+  const summaries = await fetchJson(url.toString(), { signal });
   return Array.isArray(summaries) ? summaries : [];
 }
 
@@ -147,7 +211,7 @@ function normalizeTcgdexCard(card) {
     set: {
       id: card.set?.id || '',
       name: card.set?.name || '',
-      releaseDate: card.set?.releaseDate || '',
+      releaseDate: normalizeReleaseDate(card.set?.releaseDate || ''),
     },
     images: {
       small: image,
@@ -159,23 +223,25 @@ function normalizeTcgdexCard(card) {
   };
 }
 
-async function fetchJson(url, options = {}) {
-  const response = await fetch(url, options);
-  if (!response.ok) {
-    throw new Error(`Request failed (${response.status}) for ${url}`);
-  }
-  return response.json();
-}
-
-async function hydrateTcgdexSetReleaseDates(cards = []) {
-  const uniqueSetIds = [...new Set(cards.map((card) => card?.set?.id).filter(Boolean))];
-  const missingSetIds = uniqueSetIds.filter((setId) => !tcgdexSetReleaseDateCache.has(setId));
+async function hydrateTcgdexSetReleaseDates(cards = [], signal) {
+  const uniqueSetIds = [
+    ...new Set(cards.map((card) => card?.set?.id).filter(Boolean)),
+  ];
+  const missingSetIds = uniqueSetIds.filter(
+    (setId) => !tcgdexSetReleaseDateCache.has(setId)
+  );
 
   await Promise.all(
     missingSetIds.map(async (setId) => {
       try {
-        const setData = await fetchJson(`https://api.tcgdex.net/v2/en/sets/${setId}`);
-        tcgdexSetReleaseDateCache.set(setId, setData?.releaseDate || '');
+        const setData = await fetchJson(
+          `https://api.tcgdex.net/v2/en/sets/${setId}`,
+          { signal }
+        );
+        tcgdexSetReleaseDateCache.set(
+          setId,
+          normalizeReleaseDate(setData?.releaseDate || '')
+        );
       } catch {
         tcgdexSetReleaseDateCache.set(setId, '');
       }
@@ -186,26 +252,33 @@ async function hydrateTcgdexSetReleaseDates(cards = []) {
     ...card,
     set: {
       ...card.set,
-      releaseDate: card?.set?.releaseDate || tcgdexSetReleaseDateCache.get(card?.set?.id) || '',
+      releaseDate:
+        card?.set?.releaseDate ||
+        tcgdexSetReleaseDateCache.get(card?.set?.id) ||
+        '',
     },
   }));
 }
 
-export async function queryCardsByName(term = '') {
+async function searchTcgdex(term = '', { signal } = {}) {
   const cleanName = stripWildcards(normalizeSearchQuery(String(term)));
   if (!cleanName) {
-    return { results: [], totalSummaries: 0, term: cleanName, isHugeResultSet: false };
+    return { results: [], totalSummaries: 0, isHugeResultSet: false };
   }
 
   const plan = resolveSearchPlan(cleanName);
   let allSummaries = [];
 
   if (plan.type === 'stage') {
-    allSummaries = await fetchCardSummaries({ cardName: plan.baseName, cardStage: plan.stage });
+    allSummaries = await fetchCardSummaries({
+      cardName: plan.baseName,
+      cardStage: plan.stage,
+      signal,
+    });
   } else {
     const seen = new Set();
     for (const query of plan.queries) {
-      const summaries = await fetchCardSummaries({ cardName: query });
+      const summaries = await fetchCardSummaries({ cardName: query, signal });
       for (const s of summaries) {
         if (!seen.has(s.id)) {
           seen.add(s.id);
@@ -219,7 +292,6 @@ export async function queryCardsByName(term = '') {
     return {
       results: [],
       totalSummaries: allSummaries.length,
-      term: cleanName,
       isHugeResultSet: true,
     };
   }
@@ -229,7 +301,10 @@ export async function queryCardsByName(term = '') {
   const detailedCards = await Promise.all(
     summariesToFetch.map(async (summary) => {
       try {
-        const detail = await fetchJson(`https://api.tcgdex.net/v2/en/cards/${summary.id}`);
+        const detail = await fetchJson(
+          `https://api.tcgdex.net/v2/en/cards/${summary.id}`,
+          { signal }
+        );
         return normalizeTcgdexCard(detail);
       } catch {
         return null;
@@ -238,13 +313,151 @@ export async function queryCardsByName(term = '') {
   );
 
   const validCards = detailedCards.filter((card) => card && card.image);
-
-  const hydratedCards = await hydrateTcgdexSetReleaseDates(validCards);
+  const hydratedCards = await hydrateTcgdexSetReleaseDates(validCards, signal);
 
   return {
     results: hydratedCards,
     totalSummaries: allSummaries.length,
-    term: cleanName,
     isHugeResultSet: allSummaries.length > HUGE_RESULT_THRESHOLD,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Provider: pokemontcg.io (fallback) — TCG only, no TCG Pocket coverage.
+// Single request returns full card objects (no per-card detail fetch needed).
+// ---------------------------------------------------------------------------
+
+export function normalizePokemonTcgCard(card = {}) {
+  const image = card.images?.large || card.images?.small || '';
+
+  return {
+    id: card.id,
+    name: card.name,
+    supertype: card.supertype || 'Unknown',
+    // pokemontcg.io has no single "stage" field; subtypes carry Basic/Stage 1/etc.
+    stage: Array.isArray(card.subtypes)
+      ? card.subtypes.join(' ')
+      : card.subtypes || '',
+    number: card.number || '',
+    set: {
+      id: card.set?.id || '',
+      name: card.set?.name || '',
+      releaseDate: normalizeReleaseDate(card.set?.releaseDate || ''),
+    },
+    images: {
+      small: card.images?.small || image,
+      large: card.images?.large || image,
+    },
+    image,
+    rarity: card.rarity,
+    _provider: 'pokemontcg',
+  };
+}
+
+// Same-origin proxy (see server/server.js) that forwards to pokemontcg.io. Calling
+// pokemontcg.io from the browser directly is unreliable: its 5xx error responses
+// carry no CORS headers, so an upstream outage surfaces as an opaque "Failed to
+// fetch" rather than a clean status. The proxy also attaches the API key server-side.
+export const POKEMONTCG_FALLBACK_PATH = '/api/card-fallback';
+
+// Builds the Lucene-style `q` value pokemontcg.io expects. Wildcards only work
+// unquoted, so a single-word term gets a prefix wildcard while a multi-word term
+// falls back to a quoted phrase match.
+export function buildPokemonTcgQuery(cleanName) {
+  const escaped = cleanName.replace(/"/g, '\\"');
+  return cleanName.includes(' ') ? `name:"${escaped}"` : `name:${escaped}*`;
+}
+
+async function searchPokemonTcg(term = '', { signal } = {}) {
+  const cleanName = stripWildcards(String(term).trim());
+  if (!cleanName) {
+    return { results: [], totalSummaries: 0, isHugeResultSet: false };
+  }
+
+  // URLSearchParams (not `new URL`) so the request stays a same-origin relative
+  // path in the browser and needs no base URL under Node during tests.
+  const params = new URLSearchParams({
+    q: buildPokemonTcgQuery(cleanName),
+    pageSize: String(DETAIL_FETCH_LIMIT),
+    orderBy: '-set.releaseDate',
+  });
+
+  const payload = await fetchJson(`${POKEMONTCG_FALLBACK_PATH}?${params}`, {
+    signal,
+  });
+  const data = Array.isArray(payload?.data) ? payload.data : [];
+  const totalSummaries =
+    Number(payload?.totalCount ?? data.length) || data.length;
+
+  if (totalSummaries > HUGE_RESULT_THRESHOLD) {
+    return { results: [], totalSummaries, isHugeResultSet: true };
+  }
+
+  const results = data
+    .map(normalizePokemonTcgCard)
+    .filter((card) => card && card.image);
+  return { results, totalSummaries, isHugeResultSet: false };
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration: try each provider in order, failing over on error OR timeout.
+// ---------------------------------------------------------------------------
+
+export const CARD_PROVIDERS = [
+  { name: 'tcgdex', search: searchTcgdex },
+  {
+    name: 'pokemontcg',
+    search: searchPokemonTcg,
+    fallbackNotice:
+      'tcgdex is unavailable — showing results from pokemontcg.io. TCG Pocket cards are not available from this source.',
+  },
+];
+
+// Tries providers in order; each is raced against a timeout. Returns the first
+// success (annotated with which provider served it and any fallback notice), or
+// throws the last error if every provider fails.
+export async function queryWithFallback(term = '', options = {}) {
+  const { providers = CARD_PROVIDERS, timeoutMs = SEARCH_TIMEOUT_MS } = options;
+  let lastError;
+
+  for (let i = 0; i < providers.length; i += 1) {
+    const provider = providers[i];
+    try {
+      const result = await withTimeout(
+        (signal) => provider.search(term, { signal }),
+        timeoutMs
+      );
+      return {
+        ...result,
+        term,
+        provider: provider.name,
+        usedFallback: i > 0,
+        notice: i > 0 ? provider.fallbackNotice || '' : '',
+      };
+    } catch (error) {
+      lastError = error;
+      // Fall through to the next provider.
+    }
+  }
+
+  throw lastError || new Error('All card providers failed');
+}
+
+export async function queryCardsByName(term = '') {
+  const raw = String(term);
+
+  // Empty/whitespace-only terms short-circuit without hitting the network.
+  if (!stripWildcards(normalizeSearchQuery(raw))) {
+    return {
+      results: [],
+      totalSummaries: 0,
+      term: '',
+      isHugeResultSet: false,
+      provider: null,
+      usedFallback: false,
+      notice: '',
+    };
+  }
+
+  return queryWithFallback(raw);
 }

--- a/client/src/setup/deck-builder/core/pokemon-tcg-query.mjs
+++ b/client/src/setup/deck-builder/core/pokemon-tcg-query.mjs
@@ -1,0 +1,15 @@
+function escapeLucenePhrase(value = '') {
+  return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+export function buildPokemonTcgQuery(cleanName = '') {
+  const value = String(cleanName).trim();
+  if (!value) return '';
+
+  const requiresPhrase =
+    /\s/.test(value) || /(&&|\|\||[+\-!(){}\u005b\u005d^"~*?:\\/])/.test(value);
+
+  return requiresPhrase
+    ? `name:"${escapeLucenePhrase(value)}"`
+    : `name:${value}*`;
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,7 @@ export default [
   prettier,
   eslintPluginPrettierRecommended,
   {
-    files: ['**/*.js'],
+    files: ['**/*.{js,mjs}'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "start": "pnpm -C server start",
-    "test": "node --test client/src/setup/deck-builder/__tests__/card-compare.test.mjs client/src/setup/deck-builder/__tests__/card-search.test.mjs client/src/setup/deck-builder/__tests__/card-search-sort.test.mjs client/src/setup/deck-builder/__tests__/card-sort.test.mjs client/src/setup/deck-builder/__tests__/csv-adapter.test.mjs client/src/setup/deck-builder/__tests__/deck-state.test.mjs client/src/setup/deck-builder/__tests__/deck-validation.test.mjs",
+    "test": "node --test client/src/setup/deck-builder/__tests__/card-compare.test.mjs client/src/setup/deck-builder/__tests__/card-search.test.mjs client/src/setup/deck-builder/__tests__/card-search-sort.test.mjs client/src/setup/deck-builder/__tests__/card-fallback.test.mjs client/src/setup/deck-builder/__tests__/card-sort.test.mjs client/src/setup/deck-builder/__tests__/csv-adapter.test.mjs client/src/setup/deck-builder/__tests__/deck-state.test.mjs client/src/setup/deck-builder/__tests__/deck-validation.test.mjs",
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{js,json,md}\""
   },

--- a/package.json
+++ b/package.json
@@ -2,15 +2,18 @@
   "name": "ptcg-sim",
   "version": "1.5.1",
   "private": true,
+  "engines": {
+    "node": ">=20"
+  },
   "workspaces": [
     "client",
     "server"
   ],
   "scripts": {
     "start": "pnpm -C server start",
-    "test": "node --test client/src/setup/deck-builder/__tests__/card-compare.test.mjs client/src/setup/deck-builder/__tests__/card-search.test.mjs client/src/setup/deck-builder/__tests__/card-search-sort.test.mjs client/src/setup/deck-builder/__tests__/card-fallback.test.mjs client/src/setup/deck-builder/__tests__/card-sort.test.mjs client/src/setup/deck-builder/__tests__/csv-adapter.test.mjs client/src/setup/deck-builder/__tests__/deck-state.test.mjs client/src/setup/deck-builder/__tests__/deck-validation.test.mjs",
+    "test": "node --test client/src/setup/deck-builder/__tests__/card-compare.test.mjs client/src/setup/deck-builder/__tests__/card-search.test.mjs client/src/setup/deck-builder/__tests__/card-search-sort.test.mjs client/src/setup/deck-builder/__tests__/card-fallback.test.mjs client/src/setup/deck-builder/__tests__/card-sort.test.mjs client/src/setup/deck-builder/__tests__/csv-adapter.test.mjs client/src/setup/deck-builder/__tests__/deck-state.test.mjs client/src/setup/deck-builder/__tests__/deck-validation.test.mjs server/__tests__/card-fallback.test.mjs",
     "lint": "eslint .",
-    "format": "prettier --write \"**/*.{js,json,md}\""
+    "format": "prettier --write \"**/*.{js,mjs,json,md}\""
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",

--- a/server/__tests__/card-fallback.test.mjs
+++ b/server/__tests__/card-fallback.test.mjs
@@ -1,0 +1,221 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+
+import { createCardFallbackHandler } from '../card-fallback.js';
+
+class MockResponse extends EventEmitter {
+  constructor() {
+    super();
+    this.statusCode = 200;
+    this.headers = new Map();
+    this.body = undefined;
+    this.writableEnded = false;
+    this.destroyed = false;
+  }
+
+  status(code) {
+    this.statusCode = code;
+    return this;
+  }
+
+  set(name, value) {
+    this.headers.set(name.toLowerCase(), String(value));
+    return this;
+  }
+
+  json(body) {
+    this.body = body;
+    this.writableEnded = true;
+    return this;
+  }
+}
+
+function request(term, ip = '127.0.0.1', extraQuery = {}) {
+  return {
+    ip,
+    query: { term, ...extraQuery },
+    socket: { remoteAddress: ip },
+  };
+}
+
+test('proxy constructs a fixed upstream query and attaches the API key', async () => {
+  let observed;
+  const handler = createCardFallbackHandler({
+    apiKey: 'secret-key',
+    fetchImpl: async (url, options) => {
+      observed = { url, options };
+      return new Response(JSON.stringify({ data: [], totalCount: 0 }), {
+        status: 200,
+      });
+    },
+  });
+  const res = new MockResponse();
+
+  await handler(
+    request('Mewtwo-EX', '127.0.0.1', {
+      q: 'set.id:base1',
+      pageSize: '250',
+      orderBy: 'name',
+    }),
+    res
+  );
+
+  const url = new URL(observed.url);
+  assert.equal(url.origin, 'https://api.pokemontcg.io');
+  assert.equal(url.pathname, '/v2/cards');
+  assert.equal(url.searchParams.get('q'), 'name:"Mewtwo-EX"');
+  assert.equal(url.searchParams.get('pageSize'), '150');
+  assert.equal(url.searchParams.get('orderBy'), '-set.releaseDate');
+  assert.equal(
+    url.searchParams.get('select'),
+    'id,name,supertype,subtypes,number,rarity,set,images'
+  );
+  assert.equal(observed.options.headers['X-Api-Key'], 'secret-key');
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, { data: [], totalCount: 0 });
+  assert.equal(res.headers.get('x-card-fallback-cache'), 'MISS');
+});
+
+test('proxy rejects missing, non-string, and overlong search terms', async () => {
+  const handler = createCardFallbackHandler({
+    fetchImpl: async () => {
+      throw new Error('fetch should not run');
+    },
+  });
+
+  for (const term of [undefined, ['Pikachu'], '', 'x'.repeat(121)]) {
+    const res = new MockResponse();
+    await handler(request(term), res);
+    assert.equal(res.statusCode, 400);
+  }
+});
+
+test('proxy caches successful responses by normalized term', async () => {
+  let fetchCalls = 0;
+  let currentTime = 1000;
+  const payload = { data: [{ id: 'base1-58' }], totalCount: 1 };
+  const handler = createCardFallbackHandler({
+    now: () => currentTime,
+    cacheTtlMs: 5000,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      return new Response(JSON.stringify(payload), { status: 200 });
+    },
+  });
+
+  const first = new MockResponse();
+  await handler(request('  Pikachu  '), first);
+  currentTime += 1000;
+  const second = new MockResponse();
+  await handler(request('pikachu'), second);
+
+  assert.equal(fetchCalls, 1);
+  assert.deepEqual(second.body, payload);
+  assert.equal(second.headers.get('x-card-fallback-cache'), 'HIT');
+});
+
+test('proxy enforces per-IP, global minute, and global daily rate limits', async () => {
+  let fetchCalls = 0;
+  const makeHandler = (limits) =>
+    createCardFallbackHandler({
+      ...limits,
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ data: [], totalCount: 0 }), {
+          status: 200,
+        });
+      },
+    });
+
+  const perIpHandler = makeHandler({
+    perIpRateLimitMax: 1,
+    globalRateLimitMax: 10,
+  });
+  await perIpHandler(request('Pikachu'), new MockResponse());
+  const perIpLimited = new MockResponse();
+  await perIpHandler(request('Charizard'), perIpLimited);
+  assert.equal(perIpLimited.statusCode, 429);
+  assert.equal(perIpLimited.headers.get('retry-after'), '60');
+
+  const globalHandler = makeHandler({
+    perIpRateLimitMax: 10,
+    globalRateLimitMax: 1,
+  });
+  await globalHandler(request('Mew', 'one'), new MockResponse());
+  const globallyLimited = new MockResponse();
+  await globalHandler(request('Mewtwo', 'two'), globallyLimited);
+  assert.equal(globallyLimited.statusCode, 429);
+  assert.equal(fetchCalls, 2);
+
+  const dailyHandler = makeHandler({
+    perIpRateLimitMax: 10,
+    globalRateLimitMax: 10,
+    globalDailyRateLimitMax: 1,
+  });
+  await dailyHandler(request('Eevee', 'one'), new MockResponse());
+  const dailyLimited = new MockResponse();
+  await dailyHandler(request('Vaporeon', 'two'), dailyLimited);
+  assert.equal(dailyLimited.statusCode, 429);
+  assert.equal(fetchCalls, 3);
+});
+
+test('proxy maps upstream errors and invalid payloads to 502', async () => {
+  const cases = [
+    async () => new Response('down', { status: 503 }),
+    async () => new Response('<html>', { status: 200 }),
+    async () =>
+      new Response(JSON.stringify({ unexpected: true }), { status: 200 }),
+  ];
+
+  for (const [index, fetchImpl] of cases.entries()) {
+    const handler = createCardFallbackHandler({ fetchImpl });
+    const res = new MockResponse();
+    await handler(request(`Pikachu ${index}`), res);
+    assert.equal(res.statusCode, 502);
+  }
+});
+
+test('proxy returns 504 when the upstream request times out', async () => {
+  const handler = createCardFallbackHandler({
+    upstreamTimeoutMs: 5,
+    fetchImpl: async (_url, { signal }) =>
+      new Promise((_, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => reject(new DOMException('aborted', 'AbortError')),
+          { once: true }
+        );
+      }),
+  });
+  const res = new MockResponse();
+
+  await handler(request('Pikachu'), res);
+  assert.equal(res.statusCode, 504);
+  assert.deepEqual(res.body, { error: 'Fallback provider unavailable' });
+});
+
+test('proxy aborts upstream work when the client disconnects', async () => {
+  let upstreamSignal;
+  const handler = createCardFallbackHandler({
+    fetchImpl: async (_url, { signal }) => {
+      upstreamSignal = signal;
+      return new Promise((_, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => reject(new DOMException('aborted', 'AbortError')),
+          { once: true }
+        );
+      });
+    },
+  });
+  const res = new MockResponse();
+
+  const pending = handler(request('Pikachu'), res);
+  res.destroyed = true;
+  res.emit('close');
+  await pending;
+
+  assert.equal(upstreamSignal.aborted, true);
+  assert.equal(res.body, undefined);
+});

--- a/server/card-fallback.js
+++ b/server/card-fallback.js
@@ -1,0 +1,242 @@
+import { buildPokemonTcgQuery } from '../client/src/setup/deck-builder/core/pokemon-tcg-query.mjs';
+
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_CACHE_MAX_ENTRIES = 200;
+const DEFAULT_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const DEFAULT_DAILY_RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_UPSTREAM_TIMEOUT_MS = 6000;
+const DEFAULT_MAX_RATE_LIMIT_BUCKETS = 10_000;
+const MAX_TERM_LENGTH = 120;
+
+function positiveNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+function consumeFixedWindowLimit(buckets, key, maximum, windowMs, now) {
+  const existing = buckets.get(key);
+  if (!existing || existing.resetAt <= now) {
+    buckets.set(key, { count: 1, resetAt: now + windowMs });
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+
+  if (existing.count >= maximum) {
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(
+        1,
+        Math.ceil((existing.resetAt - now) / 1000)
+      ),
+    };
+  }
+
+  existing.count += 1;
+  return { allowed: true, retryAfterSeconds: 0 };
+}
+
+function ensureRateLimitBucketCapacity(buckets, key, maxEntries) {
+  if (!buckets.has(key) && buckets.size >= maxEntries) {
+    buckets.delete(buckets.keys().next().value);
+  }
+}
+
+function setHeader(res, name, value) {
+  if (typeof res.set === 'function') res.set(name, value);
+  else res.setHeader(name, value);
+}
+
+function sendRateLimitResponse(res, retryAfterSeconds) {
+  setHeader(res, 'Retry-After', String(retryAfterSeconds));
+  return res.status(429).json({ error: 'Card fallback rate limit exceeded' });
+}
+
+export function createCardFallbackHandler(options = {}) {
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  const apiKey = options.apiKey || '';
+  const now = options.now || Date.now;
+  const cacheTtlMs = positiveNumber(options.cacheTtlMs, DEFAULT_CACHE_TTL_MS);
+  const cacheMaxEntries = positiveNumber(
+    options.cacheMaxEntries,
+    DEFAULT_CACHE_MAX_ENTRIES
+  );
+  const rateLimitWindowMs = positiveNumber(
+    options.rateLimitWindowMs,
+    DEFAULT_RATE_LIMIT_WINDOW_MS
+  );
+  const perIpRateLimitMax = positiveNumber(options.perIpRateLimitMax, 20);
+  const globalRateLimitMax = positiveNumber(
+    options.globalRateLimitMax,
+    apiKey ? 120 : 25
+  );
+  const globalDailyRateLimitMax = positiveNumber(
+    options.globalDailyRateLimitMax,
+    apiKey ? 18_000 : 900
+  );
+  const maxRateLimitBuckets = positiveNumber(
+    options.maxRateLimitBuckets,
+    DEFAULT_MAX_RATE_LIMIT_BUCKETS
+  );
+  const upstreamTimeoutMs = positiveNumber(
+    options.upstreamTimeoutMs,
+    DEFAULT_UPSTREAM_TIMEOUT_MS
+  );
+
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('A fetch implementation is required for card fallback');
+  }
+
+  const cache = new Map();
+  const perIpBuckets = new Map();
+  const globalMinuteBuckets = new Map();
+  const globalDailyBuckets = new Map();
+
+  return async function cardFallbackHandler(req, res) {
+    if (typeof req.query.term !== 'string') {
+      return res
+        .status(400)
+        .json({ error: 'Query parameter "term" is required' });
+    }
+
+    const term = req.query.term.trim().replace(/\s+/g, ' ');
+    if (!term || term.length > MAX_TERM_LENGTH) {
+      return res.status(400).json({ error: 'Invalid card search term' });
+    }
+
+    const currentTime = now();
+    const requestIp = String(req.ip || req.socket?.remoteAddress || 'unknown');
+    ensureRateLimitBucketCapacity(perIpBuckets, requestIp, maxRateLimitBuckets);
+    const perIpLimit = consumeFixedWindowLimit(
+      perIpBuckets,
+      requestIp,
+      perIpRateLimitMax,
+      rateLimitWindowMs,
+      currentTime
+    );
+    if (!perIpLimit.allowed) {
+      return sendRateLimitResponse(res, perIpLimit.retryAfterSeconds);
+    }
+
+    const cacheKey = term.toLocaleLowerCase('en');
+    const cached = cache.get(cacheKey);
+    if (cached && cached.expiresAt > currentTime) {
+      cache.delete(cacheKey);
+      cache.set(cacheKey, cached);
+      setHeader(
+        res,
+        'Cache-Control',
+        `public, max-age=${Math.floor(cacheTtlMs / 1000)}`
+      );
+      setHeader(res, 'X-Card-Fallback-Cache', 'HIT');
+      return res.json(cached.payload);
+    }
+    if (cached) cache.delete(cacheKey);
+
+    const globalLimit = consumeFixedWindowLimit(
+      globalMinuteBuckets,
+      'global',
+      globalRateLimitMax,
+      rateLimitWindowMs,
+      currentTime
+    );
+    if (!globalLimit.allowed) {
+      return sendRateLimitResponse(res, globalLimit.retryAfterSeconds);
+    }
+
+    const globalDailyLimit = consumeFixedWindowLimit(
+      globalDailyBuckets,
+      'global',
+      globalDailyRateLimitMax,
+      DEFAULT_DAILY_RATE_LIMIT_WINDOW_MS,
+      currentTime
+    );
+    if (!globalDailyLimit.allowed) {
+      return sendRateLimitResponse(res, globalDailyLimit.retryAfterSeconds);
+    }
+
+    const upstreamUrl = new URL('https://api.pokemontcg.io/v2/cards');
+    upstreamUrl.searchParams.set('q', buildPokemonTcgQuery(term));
+    upstreamUrl.searchParams.set('pageSize', '150');
+    upstreamUrl.searchParams.set('orderBy', '-set.releaseDate');
+    upstreamUrl.searchParams.set(
+      'select',
+      'id,name,supertype,subtypes,number,rarity,set,images'
+    );
+
+    const headers = { Accept: 'application/json' };
+    if (apiKey) headers['X-Api-Key'] = apiKey;
+
+    const controller = new AbortController();
+    let timedOut = false;
+    let clientDisconnected = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort(new Error('Fallback provider timed out'));
+    }, upstreamTimeoutMs);
+    const abortOnClose = () => {
+      if (!res.writableEnded) {
+        clientDisconnected = true;
+        controller.abort(new Error('Fallback client disconnected'));
+      }
+    };
+    res.once('close', abortOnClose);
+
+    try {
+      let upstream;
+      try {
+        upstream = await fetchImpl(upstreamUrl.toString(), {
+          headers,
+          signal: controller.signal,
+        });
+      } catch {
+        if (clientDisconnected || res.destroyed || res.writableEnded) return;
+        return res
+          .status(timedOut ? 504 : 502)
+          .json({ error: 'Fallback provider unavailable' });
+      }
+
+      if (clientDisconnected) return;
+
+      if (!upstream.ok) {
+        return res
+          .status(502)
+          .json({ error: `Fallback provider error (${upstream.status})` });
+      }
+
+      let payload;
+      try {
+        payload = await upstream.json();
+      } catch {
+        if (clientDisconnected || res.destroyed || res.writableEnded) return;
+        return res.status(timedOut ? 504 : 502).json({
+          error: timedOut
+            ? 'Fallback provider unavailable'
+            : 'Fallback provider returned invalid JSON',
+        });
+      }
+
+      if (clientDisconnected) return;
+
+      if (!Array.isArray(payload?.data)) {
+        return res
+          .status(502)
+          .json({ error: 'Fallback provider returned invalid data' });
+      }
+
+      cache.set(cacheKey, { payload, expiresAt: currentTime + cacheTtlMs });
+      while (cache.size > cacheMaxEntries) {
+        cache.delete(cache.keys().next().value);
+      }
+
+      setHeader(
+        res,
+        'Cache-Control',
+        `public, max-age=${Math.floor(cacheTtlMs / 1000)}`
+      );
+      setHeader(res, 'X-Card-Fallback-Cache', 'MISS');
+      return res.json(payload);
+    } finally {
+      clearTimeout(timer);
+      res.off('close', abortOnClose);
+    }
+  };
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,8 @@
 {
   "name": "ptcg-sim-server",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "start": "nodemon server.js"
   },

--- a/server/server.js
+++ b/server/server.js
@@ -9,6 +9,7 @@ import dotenv from 'dotenv';
 import sqlite3 from 'sqlite3';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
+import { createCardFallbackHandler } from './card-fallback.js';
 
 // Handle __dirname in ES modules and adjust for client folder
 const __filename = fileURLToPath(import.meta.url);
@@ -31,6 +32,10 @@ function generateRandomKey(length) {
 
 async function main() {
   const app = express();
+  const trustProxyHops = Number(process.env.TRUST_PROXY_HOPS);
+  if (Number.isInteger(trustProxyHops) && trustProxyHops > 0) {
+    app.set('trust proxy', trustProxyHops);
+  }
   // HTTP Server Setup
   const server = http.createServer(app);
 
@@ -123,50 +128,15 @@ async function main() {
   // pages omit CORS headers, so a client-side failure surfaces as an opaque
   // "Failed to fetch". Proxying keeps the fallback same-origin and lets us attach an
   // API key server-side (set POKEMONTCG_API_KEY for higher rate limits).
-  app.get('/api/card-fallback', async (req, res) => {
-    const q = req.query.q;
-    if (!q) {
-      return res.status(400).json({ error: 'Query parameter "q" is required' });
-    }
-
-    const upstreamUrl = new URL('https://api.pokemontcg.io/v2/cards');
-    upstreamUrl.searchParams.set('q', String(q));
-    upstreamUrl.searchParams.set(
-      'pageSize',
-      String(req.query.pageSize || '150')
-    );
-    upstreamUrl.searchParams.set(
-      'orderBy',
-      String(req.query.orderBy || '-set.releaseDate')
-    );
-
-    const headers = { Accept: 'application/json' };
-    if (process.env.POKEMONTCG_API_KEY) {
-      headers['X-Api-Key'] = process.env.POKEMONTCG_API_KEY;
-    }
-
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 8000);
-    try {
-      const upstream = await fetch(upstreamUrl.toString(), {
-        headers,
-        signal: controller.signal,
-      });
-      if (!upstream.ok) {
-        return res
-          .status(502)
-          .json({ error: `Fallback provider error (${upstream.status})` });
-      }
-      const payload = await upstream.json();
-      res.json(payload);
-    } catch (error) {
-      res
-        .status(504)
-        .json({ error: `Fallback provider unavailable: ${error.message}` });
-    } finally {
-      clearTimeout(timer);
-    }
-  });
+  app.get(
+    '/api/card-fallback',
+    createCardFallbackHandler({
+      apiKey: process.env.POKEMONTCG_API_KEY,
+      perIpRateLimitMax: process.env.POKEMONTCG_PER_IP_RATE_LIMIT,
+      globalRateLimitMax: process.env.POKEMONTCG_GLOBAL_RATE_LIMIT,
+      globalDailyRateLimitMax: process.env.POKEMONTCG_GLOBAL_DAILY_LIMIT,
+    })
+  );
 
   const roomInfo = new Map();
   // Function to periodically clean up empty rooms

--- a/server/server.js
+++ b/server/server.js
@@ -118,6 +118,56 @@ async function main() {
     );
   });
 
+  // Same-origin proxy for the deck builder's fallback card provider (pokemontcg.io).
+  // The browser cannot call pokemontcg.io directly on its error responses: its 5xx
+  // pages omit CORS headers, so a client-side failure surfaces as an opaque
+  // "Failed to fetch". Proxying keeps the fallback same-origin and lets us attach an
+  // API key server-side (set POKEMONTCG_API_KEY for higher rate limits).
+  app.get('/api/card-fallback', async (req, res) => {
+    const q = req.query.q;
+    if (!q) {
+      return res.status(400).json({ error: 'Query parameter "q" is required' });
+    }
+
+    const upstreamUrl = new URL('https://api.pokemontcg.io/v2/cards');
+    upstreamUrl.searchParams.set('q', String(q));
+    upstreamUrl.searchParams.set(
+      'pageSize',
+      String(req.query.pageSize || '150')
+    );
+    upstreamUrl.searchParams.set(
+      'orderBy',
+      String(req.query.orderBy || '-set.releaseDate')
+    );
+
+    const headers = { Accept: 'application/json' };
+    if (process.env.POKEMONTCG_API_KEY) {
+      headers['X-Api-Key'] = process.env.POKEMONTCG_API_KEY;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 8000);
+    try {
+      const upstream = await fetch(upstreamUrl.toString(), {
+        headers,
+        signal: controller.signal,
+      });
+      if (!upstream.ok) {
+        return res
+          .status(502)
+          .json({ error: `Fallback provider error (${upstream.status})` });
+      }
+      const payload = await upstream.json();
+      res.json(payload);
+    } catch (error) {
+      res
+        .status(504)
+        .json({ error: `Fallback provider unavailable: ${error.message}` });
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
   const roomInfo = new Map();
   // Function to periodically clean up empty rooms
   const cleanUpEmptyRooms = () => {


### PR DESCRIPTION
tcgdex is the deck builder's only card source, so any tcgdex outage or slowdown breaks card search entirely. Add a provider abstraction with automatic failover.

- card-search.mjs: refactor into a provider interface (tcgdex primary, pokemontcg.io fallback) behind queryWithFallback(), which races each provider against a 4s timeout and fails over on error OR slowness. Normalize release-date separators so cross-provider sorting is stable.
- server.js: add GET /api/card-fallback, a same-origin proxy to pokemontcg.io. Direct browser calls are unreliable because pokemontcg's 5xx error pages omit CORS headers (opaque "Failed to fetch"); the proxy also allows an API key via POKEMONTCG_API_KEY.
- native-deck-builder.js: surface a notice when results come from the fallback (pokemontcg.io has no TCG Pocket cards).
- eslint.config.mjs: apply browser/node globals to .mjs (fixes pre-existing no-undef on fetch/URL in .mjs sources).
- Add card-fallback tests (normalization + failover: error/timeout/all-fail).

Note: pokemontcg.io covers TCG only, not TCG Pocket. Pocket searches while tcgdex is down degrade to the notice above.